### PR TITLE
[codex] Refresh ingestion verification from normalized transactions

### DIFF
--- a/site/assets/api/schema.d.ts
+++ b/site/assets/api/schema.d.ts
@@ -682,7 +682,7 @@ export interface operations {
     get_api_ingestion_verification_reconciliation: {
         parameters: {
             query: {
-                shop_ref: string;
+                shop_ref?: string;
                 year: number;
                 month: number;
             };

--- a/site/assets/react/_legacy/ingestion-verification/api/ingestionVerificationApi.ts
+++ b/site/assets/react/_legacy/ingestion-verification/api/ingestionVerificationApi.ts
@@ -120,15 +120,18 @@ export function useReconciliationData(
     const reload = useCallback((): void => {
         const shopRef = nullableShopRef(params.shopRef);
 
-        if (!enabled || shopRef === undefined) {
+        if (!enabled) {
             return;
         }
 
         const query: ReconciliationQuery = {
-            shop_ref: shopRef,
             year: params.year,
             month: params.month,
         };
+
+        if (shopRef !== undefined) {
+            query.shop_ref = shopRef;
+        }
 
         void run({
             url: '/api/ingestion/verification/reconciliation',

--- a/site/assets/react/_legacy/ingestion-verification/widgets/ReconciliationSummaryWidget.tsx
+++ b/site/assets/react/_legacy/ingestion-verification/widgets/ReconciliationSummaryWidget.tsx
@@ -21,8 +21,7 @@ const ReconciliationSummaryWidget: React.FC = () => {
         month: period.month,
     }), [period.month, period.year, shopRef]);
     const debouncedParams = useDebouncedValue(queryParams, 500);
-    const canLoadReconciliation = shops.length > 0 && shopRef !== null;
-    const reconciliation = useReconciliationData(debouncedParams, canLoadReconciliation);
+    const reconciliation = useReconciliationData(debouncedParams);
 
     return (
         <div>
@@ -34,7 +33,6 @@ const ReconciliationSummaryWidget: React.FC = () => {
                                 shops={shops}
                                 value={shopRef}
                                 onChange={setShopRef}
-                                includeAll={false}
                                 disabled={shopOptions.isLoading}
                             />
                         </div>
@@ -53,31 +51,15 @@ const ReconciliationSummaryWidget: React.FC = () => {
                 <LoadingState message="Загрузка списка магазинов..." />
             )}
 
-            {!shopOptions.isError && !shopOptions.isLoading && shops.length === 0 && (
-                <EmptyState
-                    title="Магазины не найдены"
-                    message="Для сверки нужен магазин с ingestion-загрузками за последние 90 дней"
-                />
-            )}
-
-            {!shopOptions.isError && !shopOptions.isLoading && shops.length > 0 && shopRef === null && (
-                <EmptyState
-                    title="Выберите магазин"
-                    message="Сверка выполняется по конкретному магазину"
-                />
-            )}
-
-            {!shopOptions.isError && shops.length > 0 && shopRef !== null && reconciliation.isError && (
+            {!shopOptions.isError && reconciliation.isError && (
                 <ErrorState message={reconciliation.errorMessage} onRetry={reconciliation.reload} />
             )}
 
-            {!shopOptions.isError && shops.length > 0 && shopRef !== null && !reconciliation.isError && reconciliation.isLoading && (
+            {!shopOptions.isError && !reconciliation.isError && reconciliation.isLoading && (
                 <LoadingState />
             )}
 
             {!shopOptions.isError
-                && shops.length > 0
-                && shopRef !== null
                 && !reconciliation.isError
                 && !reconciliation.isLoading
                 && reconciliation.data.summary === undefined && (
@@ -85,8 +67,6 @@ const ReconciliationSummaryWidget: React.FC = () => {
             )}
 
             {!shopOptions.isError
-                && shops.length > 0
-                && shopRef !== null
                 && !reconciliation.isError
                 && !reconciliation.isLoading
                 && reconciliation.data.summary !== undefined && (

--- a/site/src/Ingestion/Application/Source/Ozon/OzonListingResolver.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonListingResolver.php
@@ -221,8 +221,17 @@ final class OzonListingResolver implements BulkListingResolverInterface
         }
 
         $items = $sourceData['items'] ?? null;
-        if (is_array($items) && isset($items[0]) && is_array($items[0])) {
-            return $this->stringValue($items[0]['sku'] ?? null);
+        if (is_array($items)) {
+            foreach ($items as $itemRow) {
+                if (!is_array($itemRow)) {
+                    continue;
+                }
+
+                $itemSku = $this->stringValue($itemRow['sku'] ?? null);
+                if (null !== $itemSku) {
+                    return $itemSku;
+                }
+            }
         }
 
         return null;
@@ -247,8 +256,17 @@ final class OzonListingResolver implements BulkListingResolverInterface
         }
 
         $items = $sourceData['items'] ?? null;
-        if (is_array($items) && isset($items[0]) && is_array($items[0])) {
-            return $this->stringValue($items[0]['name'] ?? null);
+        if (is_array($items)) {
+            foreach ($items as $itemRow) {
+                if (!is_array($itemRow)) {
+                    continue;
+                }
+
+                $itemName = $this->stringValue($itemRow['name'] ?? null);
+                if (null !== $itemName) {
+                    return $itemName;
+                }
+            }
         }
 
         return null;

--- a/site/src/Ingestion/Application/Source/Ozon/OzonListingResolver.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonListingResolver.php
@@ -134,7 +134,8 @@ final class OzonListingResolver implements BulkListingResolverInterface
             $result[$key] = null;
 
             $supplierSku = $this->stringValue($sourceData['offer_id'] ?? $sourceData['item_code'] ?? null);
-            $marketplaceSku = $this->marketplaceSku($sourceData);
+            $itemContext = $this->itemContext($sourceData);
+            $marketplaceSku = $this->marketplaceSku($sourceData, $itemContext);
 
             if (null !== $supplierSku) {
                 $supplierSkus[] = $supplierSku;
@@ -143,7 +144,7 @@ final class OzonListingResolver implements BulkListingResolverInterface
             $contextByKey[$key] = [
                 'supplierSku' => $supplierSku,
                 'marketplaceSku' => $marketplaceSku,
-                'name' => $this->listingName($sourceData),
+                'name' => $this->listingName($sourceData, $itemContext),
             ];
         }
 
@@ -204,8 +205,9 @@ final class OzonListingResolver implements BulkListingResolverInterface
 
     /**
      * @param array<string, mixed> $sourceData
+     * @param array{sku: string|null, name: string|null} $itemContext
      */
-    private function marketplaceSku(array $sourceData): ?string
+    private function marketplaceSku(array $sourceData, array $itemContext): ?string
     {
         $direct = $this->stringValue($sourceData['sku'] ?? null);
         if (null !== $direct) {
@@ -220,27 +222,14 @@ final class OzonListingResolver implements BulkListingResolverInterface
             }
         }
 
-        $items = $sourceData['items'] ?? null;
-        if (is_array($items)) {
-            foreach ($items as $itemRow) {
-                if (!is_array($itemRow)) {
-                    continue;
-                }
-
-                $itemSku = $this->stringValue($itemRow['sku'] ?? null);
-                if (null !== $itemSku) {
-                    return $itemSku;
-                }
-            }
-        }
-
-        return null;
+        return $itemContext['sku'];
     }
 
     /**
      * @param array<string, mixed> $sourceData
+     * @param array{sku: string|null, name: string|null} $itemContext
      */
-    private function listingName(array $sourceData): ?string
+    private function listingName(array $sourceData, array $itemContext): ?string
     {
         $direct = $this->stringValue($sourceData['name'] ?? null);
         if (null !== $direct) {
@@ -255,6 +244,16 @@ final class OzonListingResolver implements BulkListingResolverInterface
             }
         }
 
+        return $itemContext['name'];
+    }
+
+    /**
+     * @param array<string, mixed> $sourceData
+     *
+     * @return array{sku: string|null, name: string|null}
+     */
+    private function itemContext(array $sourceData): array
+    {
         $items = $sourceData['items'] ?? null;
         if (is_array($items)) {
             foreach ($items as $itemRow) {
@@ -263,13 +262,14 @@ final class OzonListingResolver implements BulkListingResolverInterface
                 }
 
                 $itemName = $this->stringValue($itemRow['name'] ?? null);
-                if (null !== $itemName) {
-                    return $itemName;
+                $itemSku = $this->stringValue($itemRow['sku'] ?? null);
+                if (null !== $itemSku) {
+                    return ['sku' => $itemSku, 'name' => $itemName];
                 }
             }
         }
 
-        return null;
+        return ['sku' => null, 'name' => null];
     }
 
     private function stringValue(mixed $value): ?string

--- a/site/src/Ingestion/Command/OzonAccrualRefreshFinancialVerificationCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualRefreshFinancialVerificationCommand.php
@@ -370,11 +370,16 @@ final class OzonAccrualRefreshFinancialVerificationCommand extends Command
         bool $execute,
     ): array {
         $metrics = ['batches' => 0, 'selected' => 0, 'resolved' => 0, 'updated' => 0, 'wouldCreateListings' => 0, 'unresolved' => 0];
+        $seenIds = [];
 
         for ($batch = 0; $batch < $maxBatches; ++$batch) {
-            $rows = $this->selectUnlinkedRows($companyId, $shopRef, $from, $to, $limit);
+            $rows = $this->selectUnlinkedRows($companyId, $shopRef, $from, $to, $limit, array_values($seenIds));
             if ([] === $rows) {
                 break;
+            }
+
+            foreach ($rows as $row) {
+                $seenIds[(string) $row['id']] = (string) $row['id'];
             }
 
             ++$metrics['batches'];
@@ -402,6 +407,7 @@ final class OzonAccrualRefreshFinancialVerificationCommand extends Command
         \DateTimeImmutable $from,
         \DateTimeImmutable $to,
         int $limit,
+        array $excludeIds = [],
     ): array {
         $where = [
             'source = :source',
@@ -426,6 +432,12 @@ final class OzonAccrualRefreshFinancialVerificationCommand extends Command
             $where[] = 'shop_ref = :shopRef';
             $params['shopRef'] = $shopRef;
         }
+        $types = [];
+        if ([] !== $excludeIds) {
+            $where[] = 'id NOT IN (:excludeIds)';
+            $params['excludeIds'] = $excludeIds;
+            $types['excludeIds'] = ArrayParameterType::STRING;
+        }
 
         return $this->connection->fetchAllAssociative(
             sprintf(
@@ -438,6 +450,7 @@ final class OzonAccrualRefreshFinancialVerificationCommand extends Command
                 $limit,
             ),
             $params,
+            $types,
         );
     }
 
@@ -574,13 +587,34 @@ final class OzonAccrualRefreshFinancialVerificationCommand extends Command
         }
 
         $transactionsById = [];
-        foreach ($this->transactionRepository->findBy(['id' => array_values($ids)]) as $transaction) {
-            if ($transaction instanceof FinancialTransaction) {
+        foreach ($this->idsByCompany($rows, $ids) as $companyId => $companyIds) {
+            foreach ($this->transactionRepository->findByCompanyAndIds($companyId, array_values($companyIds)) as $transaction) {
                 $transactionsById[$transaction->getId()] = $transaction;
             }
         }
 
         return $transactionsById;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param array<string, string>      $ids
+     *
+     * @return array<string, array<string, string>>
+     */
+    private function idsByCompany(array $rows, array $ids): array
+    {
+        $idsByCompany = [];
+        foreach ($rows as $row) {
+            $id = (string) $row['id'];
+            if (!isset($ids[$id])) {
+                continue;
+            }
+
+            $idsByCompany[(string) $row['company_id']][$id] = $id;
+        }
+
+        return $idsByCompany;
     }
 
     /**
@@ -616,8 +650,12 @@ final class OzonAccrualRefreshFinancialVerificationCommand extends Command
         }
 
         $items = $sourceData['items'] ?? null;
-        if (is_array($items) && isset($items[0]) && is_array($items[0])) {
-            return null !== $this->stringValue($items[0]['sku'] ?? null);
+        if (is_array($items)) {
+            foreach ($items as $itemRow) {
+                if (is_array($itemRow) && null !== $this->stringValue($itemRow['sku'] ?? null)) {
+                    return true;
+                }
+            }
         }
 
         return false;

--- a/site/src/Ingestion/Command/OzonAccrualRefreshFinancialVerificationCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualRefreshFinancialVerificationCommand.php
@@ -1,0 +1,695 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Action\NormalizeRawRecordAction;
+use App\Ingestion\Application\Action\RecordNormalizationIssueAction;
+use App\Ingestion\Application\Command\NormalizeRawRecordCommand;
+use App\Ingestion\Application\Command\RecordNormalizationIssueCommand;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayPreviewMapper;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualPreviewTransaction;
+use App\Ingestion\Application\Source\Ozon\OzonListingResolver;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\NormalizationIssueKind;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Repository\FinancialTransactionRepository;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Ingestion\Repository\NormalizationIssueRepository;
+use Doctrine\DBAL\ArrayParameterType;
+use Doctrine\DBAL\Connection;
+use Doctrine\ORM\EntityManagerInterface;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+
+#[AsCommand(
+    name: 'app:ingestion:ozon-accrual:refresh-financial-verification',
+    description: 'Replays stored Ozon accrual raw data and repairs normalized FinancialTransaction enrichment for verification reports.',
+)]
+final class OzonAccrualRefreshFinancialVerificationCommand extends Command
+{
+    use LockableTrait;
+    use OzonAccrualCommandHelperTrait;
+
+    private const BUSINESS_TIMEZONE = 'Europe/Moscow';
+
+    public function __construct(
+        private readonly ClockInterface $clock,
+        private readonly Connection $connection,
+        private readonly IngestRawRecordRepository $rawRecordRepository,
+        private readonly NormalizationIssueRepository $normalizationIssueRepository,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly NormalizeRawRecordAction $normalizeRawRecordAction,
+        private readonly RecordNormalizationIssueAction $recordNormalizationIssueAction,
+        private readonly OzonListingResolver $listingResolver,
+        private readonly RawStorageFacade $rawStorageFacade,
+        private readonly OzonAccrualByDayPreviewMapper $previewMapper,
+        private readonly FinancialTransactionRepository $transactionRepository,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('days-back', null, InputOption::VALUE_REQUIRED, 'Rolling window size. Used when --from/--to are omitted.', 45)
+            ->addOption('from', null, InputOption::VALUE_REQUIRED, 'Optional start accrual date YYYY-MM-DD. Must be paired with --to.')
+            ->addOption('to', null, InputOption::VALUE_REQUIRED, 'Optional end accrual date YYYY-MM-DD. Must be paired with --from.')
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Optional company UUID filter.')
+            ->addOption('shop-ref', null, InputOption::VALUE_REQUIRED, 'Optional shop reference filter.')
+            ->addOption('raw-limit', null, InputOption::VALUE_REQUIRED, 'Stored raw records to replay, 1..500.', 100)
+            ->addOption('relink-limit', null, InputOption::VALUE_REQUIRED, 'Unlinked transactions per enrichment batch, 1..5000.', 5000)
+            ->addOption('max-relink-batches', null, InputOption::VALUE_REQUIRED, 'Maximum enrichment batches per run, 1..50.', 20)
+            ->addOption('include-done', null, InputOption::VALUE_NONE, 'Also replay already-normalized raw records. Use for manual backfills after mapper changes.')
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Inspect selected raw records and current enrichment gaps without writing.')
+            ->addOption('execute', null, InputOption::VALUE_NONE, 'Replay selected raw records and persist enrichment repairs.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$this->lock()) {
+            $output->writeln('<comment>Ozon accrual financial verification refresh is already running.</comment>');
+
+            return Command::SUCCESS;
+        }
+
+        try {
+            return $this->runRefresh($input, new SymfonyStyle($input, $output));
+        } finally {
+            $this->release();
+        }
+    }
+
+    private function runRefresh(InputInterface $input, SymfonyStyle $io): int
+    {
+        try {
+            [$from, $to, $daysBack] = $this->dateWindow($input);
+            $companyId = $this->optionalUuidOption($input, 'company-id');
+            $shopRef = $this->optionalStringOption($input, 'shop-ref');
+            $rawLimit = $this->intOption($input, 'raw-limit', 1, 500);
+            $relinkLimit = $this->intOption($input, 'relink-limit', 1, 5000);
+            $maxRelinkBatches = $this->intOption($input, 'max-relink-batches', 1, 50);
+            $includeDone = (bool) $input->getOption('include-done');
+            $execute = $this->mode($input);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        $rawRecords = $this->rawRecords($companyId, $shopRef, $from, $to, $rawLimit, $includeDone);
+
+        $io->title('Ozon accrual financial verification refresh');
+        $io->table(
+            ['setting', 'value'],
+            [
+                ['mode', $execute ? 'execute' : 'dry-run'],
+                ['from', $from->format('Y-m-d')],
+                ['to', $to->format('Y-m-d')],
+                ['daysBack', null === $daysBack ? 'custom' : (string) $daysBack],
+                ['companyId', $companyId ?? 'all'],
+                ['shopRef', $shopRef ?? 'all'],
+                ['rawLimit', (string) $rawLimit],
+                ['includeDone', $includeDone ? 'yes' : 'no'],
+                ['relinkLimit', (string) $relinkLimit],
+                ['maxRelinkBatches', (string) $maxRelinkBatches],
+            ],
+        );
+        $this->printRawRecords($io, $rawRecords);
+
+        $normalization = $execute
+            ? $this->replayRawRecords($rawRecords)
+            : ['selected' => count($rawRecords), 'changed' => 0, 'done' => 0, 'failed' => 0];
+        $io->section('Raw replay');
+        $this->printMetrics($io, $normalization);
+
+        $enrichment = $this->repairListingEnrichment($companyId, $shopRef, $from, $to, $relinkLimit, $maxRelinkBatches, $execute);
+        $io->section('Listing enrichment repair');
+        $this->printMetrics($io, $enrichment);
+
+        if (!$execute) {
+            $io->note('Dry-run only. Use --execute to replay raw records and persist enrichment repairs.');
+        }
+
+        return 0 === $normalization['failed'] ? Command::SUCCESS : Command::FAILURE;
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable, 2: int|null}
+     */
+    private function dateWindow(InputInterface $input): array
+    {
+        $from = $this->optionalDateOption($input, 'from');
+        $to = $this->optionalDateOption($input, 'to');
+        if ((null === $from) !== (null === $to)) {
+            throw new \InvalidArgumentException('Options --from and --to must be provided together.');
+        }
+
+        if (null !== $from && null !== $to) {
+            if ($from > $to) {
+                throw new \InvalidArgumentException('--from cannot be later than --to.');
+            }
+
+            return [$from, $to, null];
+        }
+
+        $daysBack = $this->intOption($input, 'days-back', 1, 365);
+        $today = \DateTimeImmutable::createFromInterface(
+            $this->clock->now()->setTimezone(new \DateTimeZone(self::BUSINESS_TIMEZONE)),
+        )->setTime(0, 0);
+
+        return [$today->modify(sprintf('-%d days', $daysBack)), $today->modify('-1 day'), $daysBack];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function rawRecords(
+        ?string $companyId,
+        ?string $shopRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        int $limit,
+        bool $includeDone,
+    ): array {
+        $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
+        $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
+        $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
+        $windowTo = sprintf('COALESCE(j.window_to, j.window_from, %s, %s, DATE(r.fetched_at))', $externalWindowTo, $externalWindowFrom);
+        $statuses = [
+            RawNormalizationStatus::PENDING->value,
+            RawNormalizationStatus::SKIPPED->value,
+            RawNormalizationStatus::FAILED->value,
+        ];
+        if ($includeDone) {
+            $statuses[] = RawNormalizationStatus::DONE->value;
+        }
+
+        $conditions = [
+            'r.source = :source',
+            'r.resource_type = :resourceType',
+            'r.normalization_status IN (:statuses)',
+            sprintf('%s <= :toDate', $windowFrom),
+            sprintf('%s >= :fromDate', $windowTo),
+        ];
+        $params = [
+            'source' => IngestSource::OZON->value,
+            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+            'statuses' => $statuses,
+            'fromDate' => $from->format('Y-m-d'),
+            'toDate' => $to->format('Y-m-d'),
+        ];
+        $types = ['statuses' => ArrayParameterType::STRING];
+
+        if (null !== $companyId) {
+            $conditions[] = 'r.company_id = :companyId';
+            $params['companyId'] = $companyId;
+        }
+        if (null !== $shopRef && '' !== $shopRef) {
+            $conditions[] = 'r.shop_ref = :shopRef';
+            $params['shopRef'] = $shopRef;
+        }
+
+        return $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT r.company_id,
+                        r.id,
+                        r.external_id,
+                        r.shop_ref,
+                        r.fetched_at,
+                        r.byte_size,
+                        r.normalization_status,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_from,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_to
+                 FROM ingest_raw_records r
+                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
+                 WHERE %s
+                 ORDER BY CASE r.normalization_status
+                              WHEN \'pending\' THEN 0
+                              WHEN \'failed\' THEN 1
+                              WHEN \'skipped\' THEN 2
+                              ELSE 3
+                          END ASC,
+                          %s ASC,
+                          %s ASC,
+                          r.fetched_at ASC,
+                          r.created_at ASC
+                 LIMIT %d',
+                $windowFrom,
+                $windowTo,
+                implode(' AND ', $conditions),
+                $windowFrom,
+                $windowTo,
+                $limit,
+            ),
+            $params,
+            $types,
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     *
+     * @return array{selected: int, changed: int, done: int, failed: int}
+     */
+    private function replayRawRecords(array $rawRecords): array
+    {
+        $metrics = ['selected' => count($rawRecords), 'changed' => 0, 'done' => 0, 'failed' => 0];
+
+        foreach ($rawRecords as $row) {
+            $companyId = (string) $row['company_id'];
+            $rawRecordId = (string) $row['id'];
+            $record = $this->rawRecordRepository->findByIdAndCompany($rawRecordId, $companyId);
+            if (!$record instanceof IngestRawRecord || !$this->canReplay($record)) {
+                continue;
+            }
+
+            $this->prepareRecordForReplay($record);
+            $this->resolveOpenIssues($companyId, $rawRecordId);
+            $this->entityManager->flush();
+            ++$metrics['changed'];
+
+            try {
+                ($this->normalizeRawRecordAction)(new NormalizeRawRecordCommand($rawRecordId, $companyId));
+            } catch (\Throwable $exception) {
+                $this->markInlineFailure($record, $exception);
+            }
+
+            if (RawNormalizationStatus::DONE === $this->normalizationStatus($companyId, $rawRecordId)) {
+                ++$metrics['done'];
+            } else {
+                ++$metrics['failed'];
+            }
+        }
+
+        return $metrics;
+    }
+
+    private function canReplay(IngestRawRecord $record): bool
+    {
+        return in_array(
+            $record->getNormalizationStatus(),
+            [
+                RawNormalizationStatus::PENDING,
+                RawNormalizationStatus::DONE,
+                RawNormalizationStatus::SKIPPED,
+                RawNormalizationStatus::FAILED,
+            ],
+            true,
+        );
+    }
+
+    private function prepareRecordForReplay(IngestRawRecord $record): void
+    {
+        if (RawNormalizationStatus::PENDING === $record->getNormalizationStatus()) {
+            return;
+        }
+
+        if (RawNormalizationStatus::DONE === $record->getNormalizationStatus()) {
+            $record->markNormalizationFailed();
+        }
+
+        $record->markNormalizationPending();
+    }
+
+    private function resolveOpenIssues(string $companyId, string $rawRecordId): void
+    {
+        foreach ($this->normalizationIssueRepository->findOpenByRawRecord($companyId, $rawRecordId) as $issue) {
+            $issue->markResolved();
+        }
+    }
+
+    private function markInlineFailure(IngestRawRecord $record, \Throwable $exception): void
+    {
+        $record->markNormalizationFailed();
+        ($this->recordNormalizationIssueAction)(new RecordNormalizationIssueCommand(
+            companyId: $record->getCompanyId(),
+            rawRecordId: $record->getId(),
+            operationGroupId: null,
+            kind: NormalizationIssueKind::MAPPER_FAILURE,
+            details: [
+                'exceptionClass' => $exception::class,
+                'message' => $exception->getMessage(),
+                'source' => 'ozon_accrual_refresh_financial_verification',
+            ],
+        ));
+        $this->entityManager->flush();
+    }
+
+    private function normalizationStatus(string $companyId, string $rawRecordId): RawNormalizationStatus
+    {
+        $status = (string) $this->connection->fetchOne(
+            'SELECT normalization_status FROM ingest_raw_records WHERE company_id = :companyId AND id = :rawRecordId',
+            ['companyId' => $companyId, 'rawRecordId' => $rawRecordId],
+        );
+
+        return RawNormalizationStatus::from($status);
+    }
+
+    /**
+     * @return array{batches: int, selected: int, resolved: int, updated: int, wouldCreateListings: int, unresolved: int}
+     */
+    private function repairListingEnrichment(
+        ?string $companyId,
+        ?string $shopRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        int $limit,
+        int $maxBatches,
+        bool $execute,
+    ): array {
+        $metrics = ['batches' => 0, 'selected' => 0, 'resolved' => 0, 'updated' => 0, 'wouldCreateListings' => 0, 'unresolved' => 0];
+
+        for ($batch = 0; $batch < $maxBatches; ++$batch) {
+            $rows = $this->selectUnlinkedRows($companyId, $shopRef, $from, $to, $limit);
+            if ([] === $rows) {
+                break;
+            }
+
+            ++$metrics['batches'];
+            $metrics['selected'] += count($rows);
+            $result = $this->repairListingRows($rows, $execute);
+            $metrics['resolved'] += $result['resolved'];
+            $metrics['updated'] += $result['updated'];
+            $metrics['wouldCreateListings'] += $result['wouldCreateListings'];
+            $metrics['unresolved'] += count($rows) - $result['resolved'];
+
+            if (!$execute || 0 === $result['updated']) {
+                break;
+            }
+        }
+
+        return $metrics;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function selectUnlinkedRows(
+        ?string $companyId,
+        ?string $shopRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        int $limit,
+    ): array {
+        $where = [
+            'source = :source',
+            'listing_id IS NULL',
+            "(external_id LIKE :externalIdPrefix OR source_data->>'_ingestion_resource' = :resourceType)",
+            'occurred_at >= :from',
+            'occurred_at < :toExclusive',
+        ];
+        $params = [
+            'source' => IngestSource::OZON->value,
+            'externalIdPrefix' => 'ozon:accrual-by-day:%',
+            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+            'from' => $from->setTime(0, 0)->format('Y-m-d H:i:s'),
+            'toExclusive' => $to->modify('+1 day')->setTime(0, 0)->format('Y-m-d H:i:s'),
+        ];
+
+        if (null !== $companyId) {
+            $where[] = 'company_id = :companyId';
+            $params['companyId'] = $companyId;
+        }
+        if (null !== $shopRef && '' !== $shopRef) {
+            $where[] = 'shop_ref = :shopRef';
+            $params['shopRef'] = $shopRef;
+        }
+
+        return $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT id, company_id, external_id, occurred_at, source_data, raw_record_id
+                 FROM ingest_financial_transactions
+                 WHERE %s
+                 ORDER BY occurred_at ASC, id ASC
+                 LIMIT %d',
+                implode(' AND ', $where),
+                $limit,
+            ),
+            $params,
+        );
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return array{resolved: int, updated: int, wouldCreateListings: int}
+     */
+    private function repairListingRows(array $rows, bool $execute): array
+    {
+        $recoveredSourceData = $this->recoverListingSourceData($rows);
+        $sourceDataByCompany = [];
+        foreach ($rows as $row) {
+            $sourceData = $this->decodeSourceData($row['source_data'] ?? null);
+            if (!$this->hasMarketplaceSkuContext($sourceData)) {
+                $sourceData = array_merge(
+                    $sourceData,
+                    $recoveredSourceData[(string) $row['company_id']][(string) $row['raw_record_id']][(string) $row['external_id']] ?? [],
+                );
+            }
+
+            $sourceDataByCompany[(string) $row['company_id']][(string) $row['id']] = $sourceData;
+        }
+
+        $resolutions = [];
+        $wouldCreateById = [];
+        foreach ($sourceDataByCompany as $rowCompanyId => $sourceDataRows) {
+            if ($execute) {
+                $resolutions += $this->listingResolver->resolveMany($rowCompanyId, $sourceDataRows);
+                continue;
+            }
+
+            foreach ($this->listingResolver->previewMany($rowCompanyId, $sourceDataRows) as $transactionId => $preview) {
+                $resolutions[$transactionId] = $preview->resolution;
+                $wouldCreateById[$transactionId] = $preview->wouldCreate;
+            }
+        }
+
+        $resolved = 0;
+        $updated = 0;
+        $wouldCreateListings = 0;
+        $transactionsById = $execute ? $this->fetchTransactionsToUpdate($rows, $resolutions) : [];
+
+        foreach ($rows as $row) {
+            $transactionId = (string) $row['id'];
+            $resolution = $resolutions[$transactionId] ?? null;
+
+            if (null !== $resolution?->listingId && null !== $resolution->listingSku) {
+                ++$resolved;
+
+                if ($execute) {
+                    $transaction = $transactionsById[$transactionId] ?? null;
+                    if ($transaction instanceof FinancialTransaction && null === $transaction->getListingId()) {
+                        $transaction->setListing($resolution->listingId, $resolution->listingSku);
+                        ++$updated;
+                    }
+                }
+            } elseif (!$execute && true === ($wouldCreateById[$transactionId] ?? false) && null !== $resolution?->listingSku) {
+                ++$resolved;
+                ++$wouldCreateListings;
+            }
+        }
+
+        if ($execute) {
+            $this->entityManager->flush();
+        }
+
+        return ['resolved' => $resolved, 'updated' => $updated, 'wouldCreateListings' => $wouldCreateListings];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     *
+     * @return array<string, array<string, array<string, array<string, mixed>>>>
+     */
+    private function recoverListingSourceData(array $rows): array
+    {
+        $rawRecordIdsByCompany = [];
+        foreach ($rows as $row) {
+            $sourceData = $this->decodeSourceData($row['source_data'] ?? null);
+            if ($this->hasMarketplaceSkuContext($sourceData)) {
+                continue;
+            }
+
+            $companyId = $this->stringValue($row['company_id'] ?? null);
+            $rawRecordId = $this->stringValue($row['raw_record_id'] ?? null);
+            if (null === $companyId || null === $rawRecordId) {
+                continue;
+            }
+
+            $rawRecordIdsByCompany[$companyId][$rawRecordId] = $rawRecordId;
+        }
+
+        $recovered = [];
+        foreach ($rawRecordIdsByCompany as $companyId => $rawRecordIds) {
+            foreach ($rawRecordIds as $rawRecordId) {
+                try {
+                    $previewRows = $this->previewMapper->preview($companyId, $this->rawStorageFacade->read($rawRecordId, $companyId), includeSaleRefund: true);
+                } catch (\Throwable) {
+                    continue;
+                }
+
+                foreach ($previewRows as $previewRow) {
+                    $sourceData = $this->listingSourceData($previewRow);
+                    if ([] !== $sourceData) {
+                        $recovered[$companyId][$rawRecordId][$previewRow->sourceKey] = $sourceData;
+                    }
+                }
+            }
+        }
+
+        return $recovered;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @param array<string, \App\Ingestion\Application\DTO\ListingResolution|null> $resolutions
+     *
+     * @return array<string, FinancialTransaction>
+     */
+    private function fetchTransactionsToUpdate(array $rows, array $resolutions): array
+    {
+        $ids = [];
+        foreach ($rows as $row) {
+            $transactionId = (string) $row['id'];
+            $resolution = $resolutions[$transactionId] ?? null;
+            if (null !== $resolution?->listingId && null !== $resolution->listingSku) {
+                $ids[$transactionId] = $transactionId;
+            }
+        }
+
+        if ([] === $ids) {
+            return [];
+        }
+
+        $transactionsById = [];
+        foreach ($this->transactionRepository->findBy(['id' => array_values($ids)]) as $transaction) {
+            if ($transaction instanceof FinancialTransaction) {
+                $transactionsById[$transaction->getId()] = $transaction;
+            }
+        }
+
+        return $transactionsById;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function decodeSourceData(mixed $sourceData): array
+    {
+        if (is_array($sourceData)) {
+            return $sourceData;
+        }
+
+        if (!is_string($sourceData) || '' === trim($sourceData)) {
+            return [];
+        }
+
+        $decoded = json_decode($sourceData, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param array<string, mixed> $sourceData
+     */
+    private function hasMarketplaceSkuContext(array $sourceData): bool
+    {
+        if (null !== $this->stringValue($sourceData['sku'] ?? $sourceData['marketplace_sku'] ?? $sourceData['marketplaceSku'] ?? null)) {
+            return true;
+        }
+
+        $item = $sourceData['item'] ?? null;
+        if (is_array($item) && null !== $this->stringValue($item['sku'] ?? null)) {
+            return true;
+        }
+
+        $items = $sourceData['items'] ?? null;
+        if (is_array($items) && isset($items[0]) && is_array($items[0])) {
+            return null !== $this->stringValue($items[0]['sku'] ?? null);
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function listingSourceData(OzonAccrualPreviewTransaction $row): array
+    {
+        $sourceData = [];
+        if (null !== $row->marketplaceSku) {
+            $sourceData['sku'] = $row->marketplaceSku;
+        }
+        if (null !== $row->supplierSku) {
+            $sourceData['offer_id'] = $row->supplierSku;
+        }
+        if (null !== $row->listingName) {
+            $sourceData['name'] = $row->listingName;
+        }
+
+        return $sourceData;
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        if (null === $value) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return '' === $value ? null : $value;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     */
+    private function printRawRecords(SymfonyStyle $io, array $rawRecords): void
+    {
+        $io->section('Selected raw records');
+        if ([] === $rawRecords) {
+            $io->writeln('No stored Ozon accrual by-day raw records found for the selected period.');
+
+            return;
+        }
+
+        $io->table(
+            ['companyId', 'windowFrom', 'windowTo', 'rawId', 'externalId', 'shopRef', 'status', 'bytes', 'fetchedAt'],
+            array_map(static fn (array $row): array => [
+                (string) $row['company_id'],
+                (string) ($row['window_from'] ?? ''),
+                (string) ($row['window_to'] ?? ''),
+                (string) $row['id'],
+                (string) $row['external_id'],
+                (string) $row['shop_ref'],
+                (string) $row['normalization_status'],
+                (string) $row['byte_size'],
+                (string) $row['fetched_at'],
+            ], $rawRecords),
+        );
+    }
+
+    private function mode(InputInterface $input): bool
+    {
+        $dryRun = (bool) $input->getOption('dry-run');
+        $execute = (bool) $input->getOption('execute');
+
+        if ($dryRun === $execute) {
+            throw new \InvalidArgumentException('Choose exactly one action: --dry-run or --execute.');
+        }
+
+        return $execute;
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualRefreshFinancialVerificationCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualRefreshFinancialVerificationCommand.php
@@ -390,7 +390,7 @@ final class OzonAccrualRefreshFinancialVerificationCommand extends Command
             $metrics['wouldCreateListings'] += $result['wouldCreateListings'];
             $metrics['unresolved'] += count($rows) - $result['resolved'];
 
-            if (!$execute || 0 === $result['updated']) {
+            if (!$execute) {
                 break;
             }
         }

--- a/site/src/Ingestion/Controller/Api/Verification/GetReconciliationController.php
+++ b/site/src/Ingestion/Controller/Api/Verification/GetReconciliationController.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Ingestion\Controller\Api\Verification;
 
 use App\Ingestion\Application\Service\VerificationPeriodValidator;
-use App\Ingestion\Exception\InvalidPeriodException;
 use App\Ingestion\Facade\IngestionFacade;
 use App\Shared\Service\ActiveCompanyService;
 use OpenApi\Attributes as OA;
@@ -29,7 +28,7 @@ final class GetReconciliationController extends AbstractController
     }
 
     #[OA\Get(summary: 'Ingestion reconciliation summary', tags: ['Ingestion verification'])]
-    #[OA\Parameter(name: 'shop_ref', in: 'query', required: true, schema: new OA\Schema(type: 'string'))]
+    #[OA\Parameter(name: 'shop_ref', in: 'query', required: false, schema: new OA\Schema(type: 'string'))]
     #[OA\Parameter(name: 'year', in: 'query', required: true, schema: new OA\Schema(type: 'integer', minimum: 2020, maximum: 2100))]
     #[OA\Parameter(name: 'month', in: 'query', required: true, schema: new OA\Schema(type: 'integer', minimum: 1, maximum: 12))]
     #[OA\Response(
@@ -88,7 +87,7 @@ final class GetReconciliationController extends AbstractController
     public function __invoke(Request $request): JsonResponse
     {
         $companyId = (string) $this->activeCompanyService->getActiveCompany()->getId();
-        $shopRef = $this->requiredString($request->query->get('shop_ref'));
+        $shopRef = $this->nullableString($request->query->get('shop_ref'));
         $year = $request->query->getInt('year');
         $month = $request->query->getInt('month');
         $this->periodValidator->assertYearMonth($year, $month);
@@ -102,10 +101,10 @@ final class GetReconciliationController extends AbstractController
         ]);
     }
 
-    private function requiredString(mixed $value): string
+    private function nullableString(mixed $value): ?string
     {
         if (!is_string($value) || '' === trim($value)) {
-            throw new InvalidPeriodException();
+            return null;
         }
 
         return trim($value);

--- a/site/src/Ingestion/Facade/IngestionFacade.php
+++ b/site/src/Ingestion/Facade/IngestionFacade.php
@@ -102,7 +102,7 @@ final readonly class IngestionFacade
     /**
      * @return array{summary: ReconciliationSummaryView, byType: list<ReconciliationByTypeView>}
      */
-    public function getReconciliation(string $companyId, string $shopRef, int $year, int $month): array
+    public function getReconciliation(string $companyId, ?string $shopRef, int $year, int $month): array
     {
         return [
             'summary' => $this->reconciliationQuery->summary($companyId, $shopRef, $year, $month),

--- a/site/src/Ingestion/Infrastructure/Query/FinancialSummaryQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/FinancialSummaryQuery.php
@@ -4,13 +4,13 @@ declare(strict_types=1);
 
 namespace App\Ingestion\Infrastructure\Query;
 
-use App\Finance\Enum\PLFlow;
 use App\Ingestion\Application\DTO\FinancialSummaryCategoryView;
 use App\Ingestion\Application\DTO\FinancialSummaryMarketplaceCategoryView;
 use App\Ingestion\Application\DTO\FinancialSummaryMonthView;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
 use Doctrine\DBAL\Connection;
 use Doctrine\DBAL\Types\Types;
 use Webmozart\Assert\Assert;
@@ -34,35 +34,47 @@ final class FinancialSummaryQuery
         int $monthTo,
     ): array {
         Assert::uuid($companyId);
-        unset($shopRef);
 
-        $periodFrom = sprintf('%04d-%02d', $yearFrom, $monthFrom);
-        $periodTo = sprintf('%04d-%02d', $yearTo, $monthTo);
+        [$from, $toExclusive] = $this->monthRangeBounds($yearFrom, $monthFrom, $yearTo, $monthTo);
+        $conditions = [
+            'ft.company_id = :companyId',
+            'ft.occurred_at >= :from',
+            'ft.occurred_at < :toExclusive',
+        ];
+        $params = [
+            'companyId' => $companyId,
+            'from' => $from,
+            'toExclusive' => $toExclusive,
+            'inDirection' => TransactionDirection::IN->value,
+            'outDirection' => TransactionDirection::OUT->value,
+        ];
+        $types = [
+            'from' => Types::DATETIME_IMMUTABLE,
+            'toExclusive' => Types::DATETIME_IMMUTABLE,
+        ];
+        $this->addShopFilter($conditions, $params, $shopRef);
 
-        $rows = $this->connection->createQueryBuilder()
-            ->select(
-                's.period',
-                'COALESCE(SUM(s.amount_income), 0) AS income_amount',
-                'COALESCE(SUM(s.amount_expense), 0) AS expense_amount',
-            )
-            ->from('pl_monthly_snapshots', 's')
-            ->where('s.company_id = :companyId')
-            ->andWhere('s.period >= :periodFrom')
-            ->andWhere('s.period <= :periodTo')
-            ->andWhere('s.rebuilt_at IS NOT NULL')
-            ->setParameter('companyId', $companyId)
-            ->setParameter('periodFrom', $periodFrom)
-            ->setParameter('periodTo', $periodTo)
-            ->groupBy('s.period')
-            ->orderBy('s.period', 'ASC')
-            ->executeQuery()
-            ->fetchAllAssociative();
+        $rows = $this->connection->fetchAllAssociative(
+            sprintf(
+                "SELECT TO_CHAR(DATE_TRUNC('month', ft.occurred_at), 'YYYY-MM') AS period,
+                        COALESCE(SUM(CASE WHEN ft.direction = :inDirection THEN ft.amount_minor::bigint ELSE 0 END), 0) AS income_minor,
+                        COALESCE(SUM(CASE WHEN ft.direction = :outDirection THEN ABS(ft.amount_minor::bigint) ELSE 0 END), 0) AS expense_minor,
+                        COALESCE(MIN(ft.currency), 'RUB') AS currency
+                 FROM ingest_financial_transactions ft
+                 WHERE %s
+                 GROUP BY DATE_TRUNC('month', ft.occurred_at)
+                 ORDER BY DATE_TRUNC('month', ft.occurred_at) ASC",
+                implode(' AND ', $conditions),
+            ),
+            $params,
+            $types,
+        );
 
         return array_map(
             static function (array $row): FinancialSummaryMonthView {
                 [$year, $month] = array_map('intval', explode('-', (string) $row['period']));
-                $incomeMinor = self::decimalToMinor((string) $row['income_amount']);
-                $expenseMinor = self::decimalToMinor((string) $row['expense_amount']);
+                $incomeMinor = (int) $row['income_minor'];
+                $expenseMinor = (int) $row['expense_minor'];
 
                 return new FinancialSummaryMonthView(
                     year: $year,
@@ -70,7 +82,7 @@ final class FinancialSummaryQuery
                     incomeMinor: $incomeMinor,
                     expenseMinor: $expenseMinor,
                     netMinor: $incomeMinor - $expenseMinor,
-                    currency: 'RUB',
+                    currency: (string) $row['currency'],
                 );
             },
             $rows,
@@ -83,47 +95,49 @@ final class FinancialSummaryQuery
     public function byCategory(string $companyId, ?string $shopRef, int $year, int $month): array
     {
         Assert::uuid($companyId);
-        unset($shopRef);
+        [$from, $toExclusive] = $this->monthBounds($year, $month);
+        $conditions = [
+            'ft.company_id = :companyId',
+            'ft.occurred_at >= :from',
+            'ft.occurred_at < :toExclusive',
+        ];
+        $params = [
+            'companyId' => $companyId,
+            'from' => $from,
+            'toExclusive' => $toExclusive,
+        ];
+        $types = [
+            'from' => Types::DATETIME_IMMUTABLE,
+            'toExclusive' => Types::DATETIME_IMMUTABLE,
+        ];
+        $this->addShopFilter($conditions, $params, $shopRef);
 
-        $period = sprintf('%04d-%02d', $year, $month);
-
-        $rows = $this->connection->createQueryBuilder()
-            ->select(
-                'c.id AS category_id',
-                'c.name AS category_name',
-                'c.flow',
-                'COALESCE(SUM(s.amount_income), 0) AS income_amount',
-                'COALESCE(SUM(s.amount_expense), 0) AS expense_amount',
-            )
-            ->from('pl_monthly_snapshots', 's')
-            ->innerJoin('s', 'pl_categories', 'c', 'c.id = s.pl_category_id')
-            ->where('s.company_id = :companyId')
-            ->andWhere('s.period = :period')
-            ->andWhere('s.rebuilt_at IS NOT NULL')
-            ->andWhere('s.pl_category_id IS NOT NULL')
-            ->setParameter('companyId', $companyId)
-            ->setParameter('period', $period)
-            ->groupBy('c.id', 'c.name', 'c.flow')
-            ->orderBy('c.name', 'ASC')
-            ->executeQuery()
-            ->fetchAllAssociative();
+        $rows = $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT ft.type,
+                        ft.direction,
+                        COALESCE(SUM(ABS(ft.amount_minor::bigint)), 0) AS amount_minor
+                 FROM ingest_financial_transactions ft
+                 WHERE %s
+                 GROUP BY ft.type, ft.direction
+                 ORDER BY ft.direction ASC, ft.type ASC',
+                implode(' AND ', $conditions),
+            ),
+            $params,
+            $types,
+        );
 
         return array_map(
             static function (array $row): FinancialSummaryCategoryView {
-                $flow = (string) $row['flow'];
-                $incomeMinor = self::decimalToMinor((string) $row['income_amount']);
-                $expenseMinor = self::decimalToMinor((string) $row['expense_amount']);
-                $amountMinor = match ($flow) {
-                    PLFlow::INCOME->value => $incomeMinor,
-                    PLFlow::EXPENSE->value => $expenseMinor,
-                    default => $incomeMinor - $expenseMinor,
-                };
+                $type = (string) $row['type'];
+                $direction = (string) $row['direction'];
+                $transactionType = TransactionType::tryFrom($type);
 
                 return new FinancialSummaryCategoryView(
-                    categoryId: (string) $row['category_id'],
-                    categoryName: (string) $row['category_name'],
-                    flow: strtolower($flow),
-                    amountMinor: $amountMinor,
+                    categoryId: sprintf('%s:%s', $type, $direction),
+                    categoryName: $transactionType?->label() ?? $type,
+                    flow: TransactionDirection::IN->value === $direction ? 'income' : 'expense',
+                    amountMinor: (int) $row['amount_minor'],
                 );
             },
             $rows,
@@ -214,17 +228,6 @@ final class FinancialSummaryQuery
         );
     }
 
-    private static function decimalToMinor(string $amount): int
-    {
-        $amount = trim($amount);
-        $negative = str_starts_with($amount, '-');
-        $normalized = $negative ? substr($amount, 1) : $amount;
-        [$whole, $fraction] = array_pad(explode('.', $normalized, 2), 2, '0');
-        $minor = ((int) $whole * 100) + (int) str_pad(substr($fraction, 0, 2), 2, '0');
-
-        return $negative ? -$minor : $minor;
-    }
-
     /**
      * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
      */
@@ -234,5 +237,34 @@ final class FinancialSummaryQuery
         $from = new \DateTimeImmutable(sprintf('%04d-%02d-01 00:00:00', $year, $month));
 
         return [$from, $from->modify('first day of next month')];
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function monthRangeBounds(int $yearFrom, int $monthFrom, int $yearTo, int $monthTo): array
+    {
+        Assert::range($monthFrom, 1, 12);
+        Assert::range($monthTo, 1, 12);
+
+        $from = new \DateTimeImmutable(sprintf('%04d-%02d-01 00:00:00', $yearFrom, $monthFrom));
+        $to = new \DateTimeImmutable(sprintf('%04d-%02d-01 00:00:00', $yearTo, $monthTo));
+        Assert::lessThanEq($from, $to);
+
+        return [$from, $to->modify('first day of next month')];
+    }
+
+    /**
+     * @param list<string> $conditions
+     * @param array<string, mixed> $params
+     */
+    private function addShopFilter(array &$conditions, array &$params, ?string $shopRef): void
+    {
+        if (null === $shopRef || '' === trim($shopRef)) {
+            return;
+        }
+
+        $conditions[] = 'ft.shop_ref = :shopRef';
+        $params['shopRef'] = trim($shopRef);
     }
 }

--- a/site/src/Ingestion/Infrastructure/Query/ReconciliationQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/ReconciliationQuery.php
@@ -6,6 +6,8 @@ namespace App\Ingestion\Infrastructure\Query;
 
 use App\Ingestion\Application\DTO\ReconciliationByTypeView;
 use App\Ingestion\Application\DTO\ReconciliationSummaryView;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\TransactionType;
 use App\Marketplace\Repository\OzonTransactionTotalsCheckRepository;
 use Doctrine\DBAL\Connection;
@@ -36,9 +38,14 @@ final class ReconciliationQuery
             )
             ->from('ingest_financial_transactions', 'ft')
             ->where('ft.company_id = :companyId')
+            ->andWhere('ft.source = :source')
+            ->andWhere("(ft.external_id LIKE :externalIdPrefix OR ft.source_data->>'_ingestion_resource' = :resourceType)")
             ->andWhere('ft.occurred_at >= :from')
             ->andWhere('ft.occurred_at < :toExclusive')
             ->setParameter('companyId', $companyId)
+            ->setParameter('source', IngestSource::OZON->value)
+            ->setParameter('externalIdPrefix', 'ozon:accrual-by-day:%')
+            ->setParameter('resourceType', OzonResourceType::ACCRUAL_BY_DAY)
             ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
             ->setParameter('toExclusive', $toExclusive, Types::DATETIME_IMMUTABLE);
 
@@ -89,9 +96,14 @@ final class ReconciliationQuery
             )
             ->from('ingest_financial_transactions', 'ft')
             ->where('ft.company_id = :companyId')
+            ->andWhere('ft.source = :source')
+            ->andWhere("(ft.external_id LIKE :externalIdPrefix OR ft.source_data->>'_ingestion_resource' = :resourceType)")
             ->andWhere('ft.occurred_at >= :from')
             ->andWhere('ft.occurred_at < :toExclusive')
             ->setParameter('companyId', $companyId)
+            ->setParameter('source', IngestSource::OZON->value)
+            ->setParameter('externalIdPrefix', 'ozon:accrual-by-day:%')
+            ->setParameter('resourceType', OzonResourceType::ACCRUAL_BY_DAY)
             ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
             ->setParameter('toExclusive', $toExclusive, Types::DATETIME_IMMUTABLE)
             ->groupBy('ft.type')

--- a/site/src/Ingestion/Infrastructure/Query/ReconciliationQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/ReconciliationQuery.php
@@ -22,14 +22,13 @@ final class ReconciliationQuery
     ) {
     }
 
-    public function summary(string $companyId, string $shopRef, int $year, int $month): ReconciliationSummaryView
+    public function summary(string $companyId, ?string $shopRef, int $year, int $month): ReconciliationSummaryView
     {
         Assert::uuid($companyId);
-        Assert::notEmpty($shopRef);
 
         [$from, $toExclusive] = $this->monthBounds($year, $month);
 
-        $row = $this->connection->createQueryBuilder()
+        $queryBuilder = $this->connection->createQueryBuilder()
             ->select(
                 'COALESCE(SUM(ft.amount_minor), 0) AS canon_total_minor',
                 "COALESCE(MIN(ft.currency), 'RUB') AS currency",
@@ -37,15 +36,19 @@ final class ReconciliationQuery
             )
             ->from('ingest_financial_transactions', 'ft')
             ->where('ft.company_id = :companyId')
-            ->andWhere('ft.shop_ref = :shopRef')
             ->andWhere('ft.occurred_at >= :from')
             ->andWhere('ft.occurred_at < :toExclusive')
             ->setParameter('companyId', $companyId)
-            ->setParameter('shopRef', $shopRef)
             ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
-            ->setParameter('toExclusive', $toExclusive, Types::DATETIME_IMMUTABLE)
-            ->executeQuery()
-            ->fetchAssociative();
+            ->setParameter('toExclusive', $toExclusive, Types::DATETIME_IMMUTABLE);
+
+        if (null !== $shopRef && '' !== trim($shopRef)) {
+            $queryBuilder
+                ->andWhere('ft.shop_ref = :shopRef')
+                ->setParameter('shopRef', trim($shopRef));
+        }
+
+        $row = $queryBuilder->executeQuery()->fetchAssociative();
 
         $canonTotalMinor = (int) ($row['canon_total_minor'] ?? 0);
         $currency = (string) ($row['currency'] ?? 'RUB');
@@ -72,14 +75,13 @@ final class ReconciliationQuery
     /**
      * @return list<ReconciliationByTypeView>
      */
-    public function breakdownByType(string $companyId, string $shopRef, int $year, int $month): array
+    public function breakdownByType(string $companyId, ?string $shopRef, int $year, int $month): array
     {
         Assert::uuid($companyId);
-        Assert::notEmpty($shopRef);
 
         [$from, $toExclusive] = $this->monthBounds($year, $month);
 
-        $rows = $this->connection->createQueryBuilder()
+        $queryBuilder = $this->connection->createQueryBuilder()
             ->select(
                 'ft.type',
                 'COALESCE(SUM(ft.amount_minor), 0) AS canon_amount_minor',
@@ -87,11 +89,9 @@ final class ReconciliationQuery
             )
             ->from('ingest_financial_transactions', 'ft')
             ->where('ft.company_id = :companyId')
-            ->andWhere('ft.shop_ref = :shopRef')
             ->andWhere('ft.occurred_at >= :from')
             ->andWhere('ft.occurred_at < :toExclusive')
             ->setParameter('companyId', $companyId)
-            ->setParameter('shopRef', $shopRef)
             ->setParameter('from', $from, Types::DATETIME_IMMUTABLE)
             ->setParameter('toExclusive', $toExclusive, Types::DATETIME_IMMUTABLE)
             ->groupBy('ft.type')
@@ -103,9 +103,15 @@ final class ReconciliationQuery
                 ),
                 'ASC',
             )
-            ->addOrderBy('ft.type', 'ASC')
-            ->executeQuery()
-            ->fetchAllAssociative();
+            ->addOrderBy('ft.type', 'ASC');
+
+        if (null !== $shopRef && '' !== trim($shopRef)) {
+            $queryBuilder
+                ->andWhere('ft.shop_ref = :shopRef')
+                ->setParameter('shopRef', trim($shopRef));
+        }
+
+        $rows = $queryBuilder->executeQuery()->fetchAllAssociative();
 
         return array_map(
             static function (array $row): ReconciliationByTypeView {

--- a/site/src/Ingestion/Repository/FinancialTransactionRepository.php
+++ b/site/src/Ingestion/Repository/FinancialTransactionRepository.php
@@ -93,6 +93,26 @@ final class FinancialTransactionRepository extends ServiceEntityRepository imple
     }
 
     /**
+     * @param list<string> $ids
+     *
+     * @return list<FinancialTransaction>
+     */
+    public function findByCompanyAndIds(string $companyId, array $ids): array
+    {
+        if ([] === $ids) {
+            return [];
+        }
+
+        return $this->createQueryBuilder('transaction')
+            ->andWhere('transaction.companyId = :companyId')
+            ->andWhere('transaction.id IN (:ids)')
+            ->setParameter('companyId', $companyId)
+            ->setParameter('ids', array_values(array_unique($ids)))
+            ->getQuery()
+            ->getResult();
+    }
+
+    /**
      * @return iterable<FinancialTransaction>
      */
     public function iterateByPeriod(

--- a/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
+++ b/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
@@ -6,8 +6,6 @@ namespace App\Tests\Functional\Ingestion\Controller;
 
 use App\Company\Entity\Company;
 use App\Company\Entity\User;
-use App\Finance\Entity\PLMonthlySnapshot;
-use App\Finance\Enum\PLFlow;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Entity\FinancialTransaction;
 use App\Ingestion\Entity\IngestRawRecord;
@@ -22,7 +20,6 @@ use App\Marketplace\Entity\OzonTransactionTotalsCheck;
 use App\Shared\Domain\ValueObject\Money;
 use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
-use App\Tests\Builders\Finance\PLCategoryBuilder;
 use App\Tests\Support\Kernel\WebTestCaseBase;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\KernelBrowser;
@@ -66,10 +63,20 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         $client->request('GET', '/api/ingestion/verification/financial-summary?year_from=2026&month_from=6&year_to=2026&month_to=6');
         self::assertResponseIsSuccessful();
         $summary = $this->json($client);
-        self::assertSame(12345, $summary['by_month'][0]['income_minor']);
-        self::assertSame(2345, $summary['by_month'][0]['expense_minor']);
-        self::assertSame(10000, $summary['by_month'][0]['net_minor']);
-        self::assertSame('income', $summary['by_category'][1]['flow']);
+        self::assertSame(1000, $summary['by_month'][0]['income_minor']);
+        self::assertSame(500, $summary['by_month'][0]['expense_minor']);
+        self::assertSame(500, $summary['by_month'][0]['net_minor']);
+        $categoryAmounts = array_column($summary['by_category'], 'amount_minor', 'category_id');
+        ksort($categoryAmounts);
+
+        self::assertSame(
+            [
+                'commission:out' => 200,
+                'refund:out' => 300,
+                'sale:in' => 1000,
+            ],
+            $categoryAmounts,
+        );
         self::assertSame('Услуги доставки', $summary['marketplace_categories'][0]['category_group']);
         self::assertSame('Логистика', $summary['marketplace_categories'][0]['category_name']);
         self::assertSame(-200, $summary['marketplace_categories'][0]['amount_minor']);
@@ -316,7 +323,7 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         self::assertSame([1], array_column($coverage['cells'], 'issue_count'));
         self::assertSame(['shop-a'], array_column($coverage['shops'], 'shop_ref'));
 
-        $client->request('GET', '/api/ingestion/verification/reconciliation?shop_ref=shop-a&year=2026&month=6');
+        $client->request('GET', '/api/ingestion/verification/reconciliation?year=2026&month=6');
         self::assertResponseIsSuccessful();
         $reconciliation = $this->json($client);
         self::assertSame(1000, $reconciliation['summary']['canon_total_minor']);
@@ -355,25 +362,6 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         );
         $check->markOk([], ['total_minor' => 750], []);
 
-        $incomeCategory = PLCategoryBuilder::aPLCategory()
-            ->withId('33333333-3333-4333-8333-333333339100')
-            ->forCompany($company)
-            ->withName('Продажи')
-            ->withFlow(PLFlow::INCOME)
-            ->build();
-        $expenseCategory = PLCategoryBuilder::aPLCategory()
-            ->withId('33333333-3333-4333-8333-333333339101')
-            ->forCompany($company)
-            ->withName('Комиссии')
-            ->withFlow(PLFlow::EXPENSE)
-            ->build();
-        $incomeSnapshot = new PLMonthlySnapshot(Uuid::uuid7()->toString(), $company, '2026-06', $incomeCategory);
-        $incomeSnapshot->setAmountIncome('123.45');
-        $incomeSnapshot->setRebuiltAt(new \DateTimeImmutable('2026-06-20 10:00:00+00:00'));
-        $expenseSnapshot = new PLMonthlySnapshot(Uuid::uuid7()->toString(), $company, '2026-06', $expenseCategory);
-        $expenseSnapshot->setAmountExpense('23.45');
-        $expenseSnapshot->setRebuiltAt(new \DateTimeImmutable('2026-06-20 10:00:00+00:00'));
-
         $em = $this->em();
         $em->persist($owner);
         $em->persist($company);
@@ -401,10 +389,6 @@ final class VerificationApiControllerTest extends WebTestCaseBase
             ['raw' => 'hidden'],
         ));
         $em->persist($check);
-        $em->persist($incomeCategory);
-        $em->persist($expenseCategory);
-        $em->persist($incomeSnapshot);
-        $em->persist($expenseSnapshot);
         $em->flush();
 
         return [$owner, $company];
@@ -444,25 +428,6 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         );
         $checkB->markOk([], ['total_minor' => 99999], []);
 
-        $categoryA = PLCategoryBuilder::aPLCategory()
-            ->withId('33333333-3333-4333-8333-333333339200')
-            ->forCompany($companyA)
-            ->withName('Company A Sales')
-            ->withFlow(PLFlow::INCOME)
-            ->build();
-        $categoryB = PLCategoryBuilder::aPLCategory()
-            ->withId('33333333-3333-4333-8333-333333339201')
-            ->forCompany($companyB)
-            ->withName('Company B Sales')
-            ->withFlow(PLFlow::INCOME)
-            ->build();
-        $snapshotA = new PLMonthlySnapshot(Uuid::uuid7()->toString(), $companyA, '2026-06', $categoryA);
-        $snapshotA->setAmountIncome('10.00');
-        $snapshotA->setRebuiltAt(new \DateTimeImmutable('2026-06-20 10:00:00+00:00'));
-        $snapshotB = new PLMonthlySnapshot(Uuid::uuid7()->toString(), $companyB, '2026-06', $categoryB);
-        $snapshotB->setAmountIncome('999.99');
-        $snapshotB->setRebuiltAt(new \DateTimeImmutable('2026-06-20 10:00:00+00:00'));
-
         $em = $this->em();
         foreach ([$ownerA, $ownerB, $companyA, $companyB, $rawA, $rawB] as $entity) {
             $em->persist($entity);
@@ -490,7 +455,7 @@ final class VerificationApiControllerTest extends WebTestCaseBase
             NormalizationIssueKind::MAPPER_FAILURE,
             [],
         ));
-        foreach ([$checkA, $checkB, $categoryA, $categoryB, $snapshotA, $snapshotB] as $entity) {
+        foreach ([$checkA, $checkB] as $entity) {
             $em->persist($entity);
         }
         $em->flush();

--- a/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
+++ b/site/tests/Functional/Ingestion/Controller/VerificationApiControllerTest.php
@@ -499,6 +499,8 @@ final class VerificationApiControllerTest extends WebTestCaseBase
         ?TransactionDirection $direction = null,
         array $sourceData = [],
     ): FinancialTransaction {
+        $sourceData['_ingestion_resource'] ??= OzonResourceType::ACCRUAL_BY_DAY;
+
         return new FinancialTransaction(
             companyId: $companyId,
             connectionRef: 'connection-1',

--- a/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonListingResolverTest.php
+++ b/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonListingResolverTest.php
@@ -50,6 +50,12 @@ final class OzonListingResolverTest extends IntegrationTestCase
         $marketplaceResolution = $registry->resolve(IngestSource::OZON, (string) $company->getId(), [
             'item' => ['sku' => 'marketplace-sku-1'],
         ]);
+        $marketplaceResolutionFromLaterItem = $registry->resolve(IngestSource::OZON, (string) $company->getId(), [
+            'items' => [
+                ['name' => 'Item without SKU'],
+                ['sku' => 'marketplace-sku-1'],
+            ],
+        ]);
         $missingResolution = $registry->resolve(IngestSource::OZON, (string) $company->getId(), [
             'offer_id' => 'missing-offer',
         ]);
@@ -74,6 +80,9 @@ final class OzonListingResolverTest extends IntegrationTestCase
         self::assertNotNull($marketplaceResolution);
         self::assertSame($listing->getId(), $marketplaceResolution->listingId);
         self::assertSame('marketplace-sku-1', $marketplaceResolution->listingSku);
+        self::assertNotNull($marketplaceResolutionFromLaterItem);
+        self::assertSame($listing->getId(), $marketplaceResolutionFromLaterItem->listingId);
+        self::assertSame('marketplace-sku-1', $marketplaceResolutionFromLaterItem->listingSku);
         self::assertNotNull($missingResolution);
         self::assertNull($missingResolution->listingId);
         self::assertSame('missing-offer', $missingResolution->listingSku);

--- a/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonListingResolverTest.php
+++ b/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonListingResolverTest.php
@@ -70,6 +70,12 @@ final class OzonListingResolverTest extends IntegrationTestCase
             'sku' => 'new-marketplace-sku',
             'name' => 'New Ozon Listing',
         ]);
+        $createdFromLaterItemResolution = $registry->resolve(IngestSource::OZON, (string) $company->getId(), [
+            'items' => [
+                ['name' => 'Wrong Item Name'],
+                ['sku' => 'new-later-item-sku', 'name' => 'Correct Item Name'],
+            ],
+        ]);
 
         self::assertNotNull($supplierResolution);
         self::assertSame($listing->getId(), $supplierResolution->listingId);
@@ -95,14 +101,21 @@ final class OzonListingResolverTest extends IntegrationTestCase
         self::assertNotNull($createdResolution);
         self::assertNotNull($createdResolution->listingId);
         self::assertSame('new-marketplace-sku', $createdResolution->listingSku);
+        self::assertNotNull($createdFromLaterItemResolution);
+        self::assertNotNull($createdFromLaterItemResolution->listingId);
+        self::assertSame('new-later-item-sku', $createdFromLaterItemResolution->listingSku);
 
         /** @var MarketplaceListingRepository $listingRepository */
         $listingRepository = self::getContainer()->get(MarketplaceListingRepository::class);
         $createdListing = $listingRepository->findByMarketplaceSku((string) $company->getId(), MarketplaceType::OZON, 'new-marketplace-sku');
+        $createdFromLaterItemListing = $listingRepository->findByMarketplaceSku((string) $company->getId(), MarketplaceType::OZON, 'new-later-item-sku');
         self::assertNotNull($createdListing);
         self::assertSame($createdResolution->listingId, $createdListing->getId());
         self::assertSame('new-offer', $createdListing->getSupplierSku());
         self::assertSame('New Ozon Listing', $createdListing->getName());
+        self::assertNotNull($createdFromLaterItemListing);
+        self::assertSame($createdFromLaterItemResolution->listingId, $createdFromLaterItemListing->getId());
+        self::assertSame('Correct Item Name', $createdFromLaterItemListing->getName());
 
         /** @var OzonListingResolver $resolver */
         $resolver = self::getContainer()->get(OzonListingResolver::class);

--- a/site/tests/Integration/Ingestion/Command/OzonAccrualRefreshFinancialVerificationCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonAccrualRefreshFinancialVerificationCommandTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Command;
+
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Entity\FinancialTransaction;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Enum\TransactionDirection;
+use App\Ingestion\Enum\TransactionType;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Repository\IngestRawRecordRepository;
+use App\Shared\Domain\ValueObject\Money;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class OzonAccrualRefreshFinancialVerificationCommandTest extends IntegrationTestCase
+{
+    public function testExecuteProcessesPendingRawRecordByDefault(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'accrual-by-day:2026-06-01:2026-06-07',
+            fetchedAt: new \DateTimeImmutable('2026-06-08 03:00:00+00:00'),
+            rows: [$this->postingRow()],
+        );
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--shop-ref' => $connectionRef,
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-07',
+            '--raw-limit' => 10,
+            '--relink-limit' => 10,
+            '--max-relink-batches' => 1,
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+        self::assertSame(RawNormalizationStatus::DONE, $this->rawStatusById($companyId, $record->getId()));
+        self::assertSame(3, $this->transactionCount($companyId, $record->getId()));
+    }
+
+    public function testExecuteReplaysDoneRawRecordForVerificationReports(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+        $connectionRef = Uuid::uuid7()->toString();
+        $record = $this->storeRawRecord(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            externalId: 'accrual-by-day:2026-06-01:2026-06-07',
+            fetchedAt: new \DateTimeImmutable('2026-06-08 03:00:00+00:00'),
+            rows: [$this->postingRow()],
+        );
+        $operationGroupId = Uuid::uuid5(Uuid::NAMESPACE_URL, sprintf('%s:ozon:accrual-by-day:%s', $companyId, '53675409100'))->toString();
+        $this->persistExistingTransaction(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            rawRecordId: $record->getId(),
+            operationGroupId: $operationGroupId,
+            externalId: 'ozon:accrual-by-day:53675409100:sale:product-0',
+            type: TransactionType::SALE,
+            direction: TransactionDirection::IN,
+            amountMinor: 10000,
+        );
+        $this->persistExistingTransaction(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            rawRecordId: $record->getId(),
+            operationGroupId: $operationGroupId,
+            externalId: 'ozon:accrual-by-day:53675409100:commission:product-0',
+            type: TransactionType::COMMISSION,
+            direction: TransactionDirection::OUT,
+            amountMinor: 3000,
+        );
+        $record->markNormalizationDone();
+        $this->em->flush();
+
+        $defaultTester = $this->tester();
+        $defaultExit = $defaultTester->execute([
+            '--company-id' => $companyId,
+            '--shop-ref' => $connectionRef,
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-07',
+            '--raw-limit' => 10,
+            '--relink-limit' => 10,
+            '--max-relink-batches' => 1,
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $defaultExit, $defaultTester->getDisplay());
+        self::assertSame(2, $this->transactionCount($companyId, $record->getId()));
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--shop-ref' => $connectionRef,
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-07',
+            '--raw-limit' => 10,
+            '--relink-limit' => 10,
+            '--max-relink-batches' => 1,
+            '--include-done' => true,
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+        self::assertSame(RawNormalizationStatus::DONE, $this->rawStatusById($companyId, $record->getId()));
+        self::assertSame(3, $this->transactionCount($companyId, $record->getId()));
+        self::assertSame(1, $this->transactionCountByType($companyId, $record->getId(), TransactionType::BONUS));
+        self::assertSame(0, $this->duplicateNaturalKeyCount($companyId));
+        self::assertStringContainsString('Ozon accrual financial verification refresh', $tester->getDisplay());
+    }
+
+    private function tester(): CommandTester
+    {
+        $app = new Application(self::$kernel);
+
+        return new CommandTester($app->find('app:ingestion:ozon-accrual:refresh-financial-verification'));
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     */
+    private function storeRawRecord(
+        string $companyId,
+        string $connectionRef,
+        string $externalId,
+        \DateTimeImmutable $fetchedAt,
+        array $rows,
+    ): IngestRawRecord {
+        /** @var RawStorageFacade $facade */
+        $facade = self::getContainer()->get(RawStorageFacade::class);
+
+        return $facade->store(new RawBatch(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            externalId: $externalId,
+            syncJobId: Uuid::uuid7()->toString(),
+            fetchedAt: $fetchedAt,
+            rows: $rows,
+        ))[0];
+    }
+
+    private function persistExistingTransaction(
+        string $companyId,
+        string $connectionRef,
+        string $rawRecordId,
+        string $operationGroupId,
+        string $externalId,
+        TransactionType $type,
+        TransactionDirection $direction,
+        int $amountMinor,
+    ): void {
+        $this->em->persist(new FinancialTransaction(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::OZON,
+            externalId: $externalId,
+            externalUpdatedAt: new \DateTimeImmutable('2026-06-08 03:00:00+00:00'),
+            operationGroupId: $operationGroupId,
+            type: $type,
+            direction: $direction,
+            money: Money::fromMinor($amountMinor, 'RUB'),
+            occurredAt: new \DateTimeImmutable('2026-06-01 00:00:00+03:00'),
+            rawRecordId: $rawRecordId,
+            description: 'Existing Ozon accrual transaction',
+            sourceData: [],
+            sourceTz: 'Europe/Moscow',
+        ));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function postingRow(): array
+    {
+        return [
+            'accrual_id' => 53675409100,
+            'date' => '2026-06-01',
+            'unit_number' => '41774559-0885-1',
+            'accrued_category' => 'POSTING',
+            'posting' => [
+                'products' => [[
+                    'commission' => [
+                        'sale_amount' => ['amount' => '100.00', 'currency' => 'RUB'],
+                        'bonus' => ['amount' => '20.00', 'currency' => 'RUB'],
+                        'commission' => ['amount' => '-30.00', 'currency' => 'RUB'],
+                    ],
+                ]],
+            ],
+        ];
+    }
+
+    private function rawStatusById(string $companyId, string $rawRecordId): RawNormalizationStatus
+    {
+        /** @var IngestRawRecordRepository $repository */
+        $repository = self::getContainer()->get(IngestRawRecordRepository::class);
+
+        return $repository->findByIdAndCompany($rawRecordId, $companyId)?->getNormalizationStatus()
+            ?? throw new \RuntimeException('Raw record was not found.');
+    }
+
+    private function transactionCount(string $companyId, string $rawRecordId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_financial_transactions WHERE company_id = :companyId AND raw_record_id = :rawRecordId',
+            ['companyId' => $companyId, 'rawRecordId' => $rawRecordId],
+        );
+    }
+
+    private function transactionCountByType(string $companyId, string $rawRecordId, TransactionType $type): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_financial_transactions WHERE company_id = :companyId AND raw_record_id = :rawRecordId AND type = :type',
+            ['companyId' => $companyId, 'rawRecordId' => $rawRecordId, 'type' => $type->value],
+        );
+    }
+
+    private function duplicateNaturalKeyCount(string $companyId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*)
+             FROM (
+                 SELECT external_id, type
+                 FROM ingest_financial_transactions
+                 WHERE company_id = :companyId
+                   AND source = :source
+                 GROUP BY external_id, type
+                 HAVING COUNT(*) > 1
+             ) duplicate_keys',
+            ['companyId' => $companyId, 'source' => IngestSource::OZON->value],
+        );
+    }
+}

--- a/site/tests/Integration/Ingestion/Command/OzonAccrualRefreshFinancialVerificationCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonAccrualRefreshFinancialVerificationCommandTest.php
@@ -15,6 +15,8 @@ use App\Ingestion\Enum\TransactionType;
 use App\Ingestion\Facade\RawStorageFacade;
 use App\Ingestion\Repository\IngestRawRecordRepository;
 use App\Shared\Domain\ValueObject\Money;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Support\Kernel\IntegrationTestCase;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
@@ -23,6 +25,59 @@ use Symfony\Component\Console\Tester\CommandTester;
 
 final class OzonAccrualRefreshFinancialVerificationCommandTest extends IntegrationTestCase
 {
+    public function testExecuteDoesNotDoubleCountUnresolvedEnrichmentRowsAcrossBatches(): void
+    {
+        $owner = UserBuilder::aUser()->withIndex(9510)->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId('11111111-1111-4111-8111-111111119510')
+            ->withOwner($owner)
+            ->build();
+        $companyId = (string) $company->getId();
+        $connectionRef = Uuid::uuid7()->toString();
+        $rawRecordId = Uuid::uuid7()->toString();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+        $this->persistExistingTransaction(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            rawRecordId: $rawRecordId,
+            operationGroupId: Uuid::uuid7()->toString(),
+            externalId: 'ozon:accrual-by-day:95100000001:bonus:product-0',
+            type: TransactionType::BONUS,
+            direction: TransactionDirection::IN,
+            amountMinor: 100,
+            sourceData: ['sku' => 'metric-sku-1', 'name' => 'Metric SKU 1'],
+        );
+        $this->persistExistingTransaction(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            rawRecordId: $rawRecordId,
+            operationGroupId: Uuid::uuid7()->toString(),
+            externalId: 'ozon:accrual-by-day:95100000002:non_item_fee:type-12',
+            type: TransactionType::OTHER,
+            direction: TransactionDirection::OUT,
+            amountMinor: -50,
+        );
+        $this->em->flush();
+
+        $tester = $this->tester();
+        $exit = $tester->execute([
+            '--company-id' => $companyId,
+            '--shop-ref' => $connectionRef,
+            '--from' => '2026-06-01',
+            '--to' => '2026-06-07',
+            '--raw-limit' => 10,
+            '--relink-limit' => 2,
+            '--max-relink-batches' => 2,
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit, $tester->getDisplay());
+        self::assertSame(1, $this->linkedTransactionCount($companyId));
+        self::assertMatchesRegularExpression('/Listing enrichment repair[\s\S]*selected\s+2[\s\S]*updated\s+1[\s\S]*unresolved\s+1/', $tester->getDisplay());
+    }
+
     public function testExecuteProcessesPendingRawRecordByDefault(): void
     {
         $companyId = Uuid::uuid7()->toString();
@@ -165,6 +220,7 @@ final class OzonAccrualRefreshFinancialVerificationCommandTest extends Integrati
         TransactionType $type,
         TransactionDirection $direction,
         int $amountMinor,
+        array $sourceData = [],
     ): void {
         $this->em->persist(new FinancialTransaction(
             companyId: $companyId,
@@ -180,7 +236,7 @@ final class OzonAccrualRefreshFinancialVerificationCommandTest extends Integrati
             occurredAt: new \DateTimeImmutable('2026-06-01 00:00:00+03:00'),
             rawRecordId: $rawRecordId,
             description: 'Existing Ozon accrual transaction',
-            sourceData: [],
+            sourceData: $sourceData,
             sourceTz: 'Europe/Moscow',
         ));
     }
@@ -229,6 +285,14 @@ final class OzonAccrualRefreshFinancialVerificationCommandTest extends Integrati
         return (int) $this->connection->fetchOne(
             'SELECT COUNT(*) FROM ingest_financial_transactions WHERE company_id = :companyId AND raw_record_id = :rawRecordId AND type = :type',
             ['companyId' => $companyId, 'rawRecordId' => $rawRecordId, 'type' => $type->value],
+        );
+    }
+
+    private function linkedTransactionCount(string $companyId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_financial_transactions WHERE company_id = :companyId AND listing_id IS NOT NULL',
+            ['companyId' => $companyId],
         );
     }
 

--- a/site/tests/Integration/Ingestion/Command/OzonAccrualRefreshFinancialVerificationCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonAccrualRefreshFinancialVerificationCommandTest.php
@@ -43,21 +43,23 @@ final class OzonAccrualRefreshFinancialVerificationCommandTest extends Integrati
             connectionRef: $connectionRef,
             rawRecordId: $rawRecordId,
             operationGroupId: Uuid::uuid7()->toString(),
-            externalId: 'ozon:accrual-by-day:95100000001:bonus:product-0',
-            type: TransactionType::BONUS,
-            direction: TransactionDirection::IN,
-            amountMinor: 100,
-            sourceData: ['sku' => 'metric-sku-1', 'name' => 'Metric SKU 1'],
+            externalId: 'ozon:accrual-by-day:95100000001:non_item_fee:type-12',
+            type: TransactionType::OTHER,
+            direction: TransactionDirection::OUT,
+            amountMinor: -50,
+            occurredAt: new \DateTimeImmutable('2026-06-01 00:00:00+03:00'),
         );
         $this->persistExistingTransaction(
             companyId: $companyId,
             connectionRef: $connectionRef,
             rawRecordId: $rawRecordId,
             operationGroupId: Uuid::uuid7()->toString(),
-            externalId: 'ozon:accrual-by-day:95100000002:non_item_fee:type-12',
-            type: TransactionType::OTHER,
-            direction: TransactionDirection::OUT,
-            amountMinor: -50,
+            externalId: 'ozon:accrual-by-day:95100000002:bonus:product-0',
+            type: TransactionType::BONUS,
+            direction: TransactionDirection::IN,
+            amountMinor: 100,
+            sourceData: ['sku' => 'metric-sku-1', 'name' => 'Metric SKU 1'],
+            occurredAt: new \DateTimeImmutable('2026-06-01 00:01:00+03:00'),
         );
         $this->em->flush();
 
@@ -68,7 +70,7 @@ final class OzonAccrualRefreshFinancialVerificationCommandTest extends Integrati
             '--from' => '2026-06-01',
             '--to' => '2026-06-07',
             '--raw-limit' => 10,
-            '--relink-limit' => 2,
+            '--relink-limit' => 1,
             '--max-relink-batches' => 2,
             '--execute' => true,
         ]);
@@ -221,6 +223,7 @@ final class OzonAccrualRefreshFinancialVerificationCommandTest extends Integrati
         TransactionDirection $direction,
         int $amountMinor,
         array $sourceData = [],
+        ?\DateTimeImmutable $occurredAt = null,
     ): void {
         $this->em->persist(new FinancialTransaction(
             companyId: $companyId,
@@ -233,7 +236,7 @@ final class OzonAccrualRefreshFinancialVerificationCommandTest extends Integrati
             type: $type,
             direction: $direction,
             money: Money::fromMinor($amountMinor, 'RUB'),
-            occurredAt: new \DateTimeImmutable('2026-06-01 00:00:00+03:00'),
+            occurredAt: $occurredAt ?? new \DateTimeImmutable('2026-06-01 00:00:00+03:00'),
             rawRecordId: $rawRecordId,
             description: 'Existing Ozon accrual transaction',
             sourceData: $sourceData,

--- a/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace App\Tests\Integration\Ingestion\Infrastructure\Query;
 
-use App\Finance\Entity\PLMonthlySnapshot;
-use App\Finance\Enum\PLFlow;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Entity\FinancialTransaction;
 use App\Ingestion\Entity\IngestRawRecord;
@@ -23,9 +21,6 @@ use App\Ingestion\Infrastructure\Query\IssuesQuery;
 use App\Ingestion\Infrastructure\Query\ReconciliationQuery;
 use App\Marketplace\Entity\OzonTransactionTotalsCheck;
 use App\Shared\Domain\ValueObject\Money;
-use App\Tests\Builders\Company\CompanyBuilder;
-use App\Tests\Builders\Company\UserBuilder;
-use App\Tests\Builders\Finance\PLCategoryBuilder;
 use App\Tests\Support\Kernel\IntegrationTestCase;
 use Ramsey\Uuid\Uuid;
 
@@ -484,11 +479,14 @@ final class VerificationQueriesTest extends IntegrationTestCase
         $query = self::getContainer()->get(ReconciliationQuery::class);
 
         $summary = $query->summary($companyId, 'shop-1', 2026, 6);
+        $companySummary = $query->summary($companyId, null, 2026, 6);
         $byType = $query->breakdownByType($companyId, 'shop-1', 2026, 6);
 
         self::assertSame(500, $summary->canonTotalMinor);
         self::assertSame(750, $summary->ozonControlTotalMinor);
         self::assertSame(-250, $summary->canonVsOzonDeltaMinor);
+        self::assertSame(1499, $companySummary->canonTotalMinor);
+        self::assertSame(749, $companySummary->canonVsOzonDeltaMinor);
         self::assertSame('RUB', $summary->currency);
         self::assertSame(['sale', 'refund', 'commission'], array_column($byType, 'type'));
         self::assertSame(
@@ -546,66 +544,63 @@ final class VerificationQueriesTest extends IntegrationTestCase
         );
     }
 
-    public function testFinancialSummaryUsesOnlyRebuiltMonthlySnapshots(): void
+    public function testFinancialSummaryUsesNormalizedTransactionsAndOptionalShopScope(): void
     {
-        $owner = UserBuilder::aUser()->withIndex(9001)->build();
-        $company = CompanyBuilder::aCompany()
-            ->withId('11111111-1111-4111-8111-111111119001')
-            ->withOwner($owner)
-            ->build();
-        $incomeCategory = PLCategoryBuilder::aPLCategory()
-            ->withId('33333333-3333-4333-8333-333333339001')
-            ->forCompany($company)
-            ->withName('Продажи')
-            ->withFlow(PLFlow::INCOME)
-            ->build();
-        $expenseCategory = PLCategoryBuilder::aPLCategory()
-            ->withId('33333333-3333-4333-8333-333333339002')
-            ->forCompany($company)
-            ->withName('Комиссии')
-            ->withFlow(PLFlow::EXPENSE)
-            ->build();
-        $legacyCategory = PLCategoryBuilder::aPLCategory()
-            ->withId('33333333-3333-4333-8333-333333339003')
-            ->forCompany($company)
-            ->withName('Legacy')
-            ->withFlow(PLFlow::INCOME)
-            ->build();
+        $companyId = Uuid::uuid7()->toString();
+        $raw = $this->rawRecord(
+            companyId: $companyId,
+            shopRef: 'shop-1',
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            fetchedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            externalId: 'financial-summary-raw-1',
+        );
+        $otherShopRaw = $this->rawRecord(
+            companyId: $companyId,
+            shopRef: 'shop-2',
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            fetchedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            externalId: 'financial-summary-raw-2',
+        );
 
-        $incomeSnapshot = new PLMonthlySnapshot(Uuid::uuid7()->toString(), $company, '2026-06', $incomeCategory);
-        $incomeSnapshot->setAmountIncome('123.45');
-        $incomeSnapshot->setRebuiltAt(new \DateTimeImmutable('2026-06-20 10:00:00+00:00'));
-
-        $expenseSnapshot = new PLMonthlySnapshot(Uuid::uuid7()->toString(), $company, '2026-06', $expenseCategory);
-        $expenseSnapshot->setAmountExpense('23.45');
-        $expenseSnapshot->setRebuiltAt(new \DateTimeImmutable('2026-06-20 10:00:00+00:00'));
-
-        $legacySnapshot = new PLMonthlySnapshot(Uuid::uuid7()->toString(), $company, '2026-06', $legacyCategory);
-        $legacySnapshot->setAmountIncome('999.99');
-
-        $this->em->persist($owner);
-        $this->em->persist($company);
-        $this->em->persist($incomeCategory);
-        $this->em->persist($expenseCategory);
-        $this->em->persist($legacyCategory);
-        $this->em->persist($incomeSnapshot);
-        $this->em->persist($expenseSnapshot);
-        $this->em->persist($legacySnapshot);
+        $this->em->persist($raw);
+        $this->em->persist($otherShopRaw);
+        $this->em->persist($this->transaction($companyId, $raw->getId(), 'summary-sale-1', 1000, TransactionType::SALE));
+        $this->em->persist($this->transaction($companyId, $raw->getId(), 'summary-commission-1', -200, TransactionType::COMMISSION));
+        $this->em->persist($this->transaction($companyId, $otherShopRaw->getId(), 'summary-sale-2', 500, TransactionType::SALE, 'shop-2'));
+        $this->em->persist($this->transaction($companyId, $otherShopRaw->getId(), 'summary-refund-2', -100, TransactionType::REFUND, 'shop-2'));
+        $this->em->persist($this->transaction(
+            $companyId,
+            $raw->getId(),
+            'summary-july-ignored',
+            99999,
+            TransactionType::SALE,
+            occurredAt: new \DateTimeImmutable('2026-07-01 00:00:00+00:00'),
+        ));
         $this->em->flush();
 
         /** @var FinancialSummaryQuery $query */
         $query = self::getContainer()->get(FinancialSummaryQuery::class);
 
-        $byMonth = $query->byMonth($company->getId(), null, 2026, 6, 2026, 6);
-        $byCategory = $query->byCategory($company->getId(), null, 2026, 6);
+        $allShopsMonth = $query->byMonth($companyId, null, 2026, 6, 2026, 6);
+        $shopOneMonth = $query->byMonth($companyId, 'shop-1', 2026, 6, 2026, 6);
+        $byCategory = $query->byCategory($companyId, null, 2026, 6);
 
-        self::assertCount(1, $byMonth);
-        self::assertSame(12345, $byMonth[0]->incomeMinor);
-        self::assertSame(2345, $byMonth[0]->expenseMinor);
-        self::assertSame(10000, $byMonth[0]->netMinor);
+        self::assertCount(1, $allShopsMonth);
+        self::assertSame(1500, $allShopsMonth[0]->incomeMinor);
+        self::assertSame(300, $allShopsMonth[0]->expenseMinor);
+        self::assertSame(1200, $allShopsMonth[0]->netMinor);
+        self::assertSame(1000, $shopOneMonth[0]->incomeMinor);
+        self::assertSame(200, $shopOneMonth[0]->expenseMinor);
+        $categoryAmounts = array_column($byCategory, 'amountMinor', 'categoryId');
+        ksort($categoryAmounts);
+
         self::assertSame(
-            ['Комиссии' => 2345, 'Продажи' => 12345],
-            array_column($byCategory, 'amountMinor', 'categoryName'),
+            [
+                'commission:out' => 200,
+                'refund:out' => 100,
+                'sale:in' => 1500,
+            ],
+            $categoryAmounts,
         );
     }
 
@@ -836,6 +831,7 @@ final class VerificationQueriesTest extends IntegrationTestCase
         int $amountMinor,
         TransactionType $type,
         string $shopRef = 'shop-1',
+        ?\DateTimeImmutable $occurredAt = null,
     ): FinancialTransaction {
         return new FinancialTransaction(
             companyId: $companyId,
@@ -848,7 +844,7 @@ final class VerificationQueriesTest extends IntegrationTestCase
             type: $type,
             direction: $amountMinor >= 0 ? TransactionDirection::IN : TransactionDirection::OUT,
             money: Money::fromMinor($amountMinor, 'RUB'),
-            occurredAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
+            occurredAt: $occurredAt ?? new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
             rawRecordId: $rawRecordId,
         );
     }

--- a/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
+++ b/site/tests/Integration/Ingestion/Infrastructure/Query/VerificationQueriesTest.php
@@ -464,6 +464,7 @@ final class VerificationQueriesTest extends IntegrationTestCase
         $this->em->persist($this->transaction($companyId, $rawRecordId, 'refund-1', -300, TransactionType::REFUND));
         $this->em->persist($this->transaction($companyId, $rawRecordId, 'commission-1', -200, TransactionType::COMMISSION));
         $this->em->persist($this->transaction($companyId, $rawRecordId, 'other-shop-sale', 999, TransactionType::SALE, 'shop-2'));
+        $this->em->persist($this->transaction($companyId, $rawRecordId, 'wb-sale-noise', 7777, TransactionType::SALE, source: IngestSource::WILDBERRIES));
 
         $check = new OzonTransactionTotalsCheck(
             companyId: $companyId,
@@ -832,12 +833,17 @@ final class VerificationQueriesTest extends IntegrationTestCase
         TransactionType $type,
         string $shopRef = 'shop-1',
         ?\DateTimeImmutable $occurredAt = null,
+        ?IngestSource $source = null,
+        ?array $sourceData = null,
     ): FinancialTransaction {
+        $source ??= IngestSource::OZON;
+        $sourceData ??= IngestSource::OZON === $source ? ['_ingestion_resource' => OzonResourceType::ACCRUAL_BY_DAY] : [];
+
         return new FinancialTransaction(
             companyId: $companyId,
             connectionRef: 'connection-1',
             shopRef: $shopRef,
-            source: IngestSource::OZON,
+            source: $source,
             externalId: $externalId,
             externalUpdatedAt: new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
             operationGroupId: Uuid::uuid7()->toString(),
@@ -846,6 +852,7 @@ final class VerificationQueriesTest extends IntegrationTestCase
             money: Money::fromMinor($amountMinor, 'RUB'),
             occurredAt: $occurredAt ?? new \DateTimeImmutable('2026-06-15 10:00:00+00:00'),
             rawRecordId: $rawRecordId,
+            sourceData: $sourceData,
         );
     }
 }


### PR DESCRIPTION
## What changed

- Switched Ingestion financial summary from `pl_monthly_snapshots` to normalized `ingest_financial_transactions`.
- Made reconciliation work at company scope when `shop_ref` is omitted, while preserving optional shop filtering.
- Scoped all-shop reconciliation totals to Ozon accrual financial transactions so non-Ozon ingestion rows are not compared with Ozon control totals.
- Updated the reconciliation UI/API typing so the “all shops” view can load without selecting a specific shop.
- Added `app:ingestion:ozon-accrual:refresh-financial-verification` to replay stored Ozon accrual raw records and repair `FinancialTransaction` listing enrichment inside the Ingestion module.
- Added coverage for the verification queries, API payloads, Ozon listing resolver, and the new refresh command.

## Why

The verification pages should reflect the already-normalized Ingestion projection. Ozon can also change accrual data retroactively, so Ingestion needs an operational command to replay stored raw snapshots and repair enrichment without involving PnL, Finance snapshots, Marketplace month close, or external refetching.

## Review follow-up

- Replaced unscoped transaction lookup with `FinancialTransactionRepository::findByCompanyAndIds()`.
- Prevented enrichment metrics from double-counting unresolved rows across execute batches.
- Kept execute relink paging past unresolved-only batches so later linkable rows are still repaired.
- Updated Ozon SKU/name extraction to scan all `items[*]` and keep listing name aligned with the item that supplied the resolved SKU.
- Added regression coverage for non-Ozon all-shop reconciliation noise, unresolved-only relink paging, and SKU/name alignment from later `items[*]` rows.

## Operational notes

- Default command behavior processes `pending`, `failed`, and `skipped` raw records plus enrichment repair.
- Use `--include-done` explicitly for manual backfill/replay after mapper changes.
- No production cron config is changed in this PR.

## Checks

- `docker compose run --rm -e DATABASE_URL='postgresql://app:secret@symfony-postgres:5432/app_test?serverVersion=15&charset=utf8' -e APP_ENV=test -e APP_DEBUG=1 site-php-cli php bin/phpunit -c phpunit.xml --filter 'VerificationQueriesTest|VerificationApiControllerTest|OzonAccrualRefreshFinancialVerificationCommandTest|OzonListingResolverTest'` — OK, 23 tests, 246 assertions; PHPUnit deprecations are existing noise
- `docker compose run --rm -T site-frontend npm run build` — OK
- `docker compose run --rm -T site-frontend npx eslint assets/react/_legacy/ingestion-verification/api/ingestionVerificationApi.ts assets/react/_legacy/ingestion-verification/widgets/ReconciliationSummaryWidget.tsx --max-warnings=0` — OK
- PHP syntax checks for changed PHP files — OK
- `git diff --check` on scoped files — OK