### PR TITLE
[codex] Fix Ozon accrual raw coverage selection

### DIFF
--- a/site/src/Ingestion/Application/Action/RefreshOzonAccrualCategoryMetadataAction.php
+++ b/site/src/Ingestion/Application/Action/RefreshOzonAccrualCategoryMetadataAction.php
@@ -6,11 +6,11 @@ namespace App\Ingestion\Application\Action;
 
 use App\Ingestion\Application\DTO\MappedTransaction;
 use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayMapper;
-use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Entity\FinancialTransaction;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\RawNormalizationStatus;
 use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Infrastructure\Query\OzonAccrualRawRecordQuery;
 use App\Ingestion\Repository\FinancialTransactionRepository;
 use App\Ingestion\Repository\IngestRawRecordRepository;
 use Doctrine\DBAL\Connection;
@@ -40,6 +40,7 @@ final readonly class RefreshOzonAccrualCategoryMetadataAction
         private RawStorageFacade $rawStorageFacade,
         private OzonAccrualByDayMapper $mapper,
         private EntityManagerInterface $entityManager,
+        private OzonAccrualRawRecordQuery $rawRecordQuery,
     ) {
     }
 
@@ -73,59 +74,14 @@ final readonly class RefreshOzonAccrualCategoryMetadataAction
         int $limit,
         int $offset = 0,
     ): array {
-        $limit = max(1, min(500, $limit));
-        $offset = max(0, $offset);
-        $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
-        $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
-        $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
-        $windowTo = sprintf('COALESCE(j.window_to, j.window_from, %s, %s, DATE(r.fetched_at))', $externalWindowTo, $externalWindowFrom);
-        $conditions = [
-            'r.company_id = :companyId',
-            'r.source = :source',
-            'r.resource_type = :resourceType',
-            'r.normalization_status = :status',
-            sprintf('%s <= :toDate', $windowFrom),
-            sprintf('%s >= :fromDate', $windowTo),
-        ];
-        $params = [
-            'companyId' => $companyId,
-            'source' => IngestSource::OZON->value,
-            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
-            'status' => RawNormalizationStatus::DONE->value,
-            'fromDate' => $from->format('Y-m-d'),
-            'toDate' => $to->format('Y-m-d'),
-        ];
-
-        if (null !== $shopRef && '' !== $shopRef) {
-            $conditions[] = 'r.shop_ref = :shopRef';
-            $params['shopRef'] = $shopRef;
-        }
-
-        return $this->connection->fetchAllAssociative(
-            sprintf(
-                'SELECT r.id,
-                        r.external_id,
-                        r.shop_ref,
-                        r.fetched_at,
-                        r.byte_size,
-                        r.normalization_status,
-                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_from,
-                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_to
-                 FROM ingest_raw_records r
-                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
-                 WHERE %s
-                 ORDER BY %s ASC, %s ASC, r.fetched_at ASC, r.created_at ASC
-                 LIMIT %d
-                 OFFSET %d',
-                $windowFrom,
-                $windowTo,
-                implode(' AND ', $conditions),
-                $windowFrom,
-                $windowTo,
-                $limit,
-                $offset,
-            ),
-            $params,
+        return $this->rawRecordQuery->latestCoverageRows(
+            $companyId,
+            $shopRef,
+            $from,
+            $to,
+            max(1, min(500, $limit)),
+            [RawNormalizationStatus::DONE->value],
+            max(0, $offset),
         );
     }
 
@@ -134,42 +90,7 @@ final readonly class RefreshOzonAccrualCategoryMetadataAction
      */
     public function rawRecord(string $companyId, string $rawRecordId): ?array
     {
-        $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
-        $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
-        $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
-        $windowTo = sprintf('COALESCE(j.window_to, j.window_from, %s, %s, DATE(r.fetched_at))', $externalWindowTo, $externalWindowFrom);
-
-        $row = $this->connection->fetchAssociative(
-            sprintf(
-                'SELECT r.id,
-                        r.external_id,
-                        r.shop_ref,
-                        r.fetched_at,
-                        r.byte_size,
-                        r.normalization_status,
-                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_from,
-                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_to
-                 FROM ingest_raw_records r
-                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
-                 WHERE r.id = :rawRecordId
-                   AND r.company_id = :companyId
-                   AND r.source = :source
-                   AND r.resource_type = :resourceType
-                   AND r.normalization_status = :status
-                 LIMIT 1',
-                $windowFrom,
-                $windowTo,
-            ),
-            [
-                'rawRecordId' => $rawRecordId,
-                'companyId' => $companyId,
-                'source' => IngestSource::OZON->value,
-                'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
-                'status' => RawNormalizationStatus::DONE->value,
-            ],
-        );
-
-        return false === $row ? null : $row;
+        return $this->rawRecordQuery->doneRawRecord($companyId, $rawRecordId);
     }
 
     /**

--- a/site/src/Ingestion/Application/Source/Ozon/OzonAccrualRawCoverageSelector.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonAccrualRawCoverageSelector.php
@@ -1,0 +1,138 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Application\Source\Ozon;
+
+/**
+ * Selects the newest non-overlapping raw coverage for Ozon accrual by-day rows.
+ *
+ * @phpstan-type RawRow array<string, mixed>
+ */
+final readonly class OzonAccrualRawCoverageSelector
+{
+    /**
+     * @param list<RawRow> $candidates
+     *
+     * @return list<RawRow>
+     */
+    public function selectLatest(array $candidates, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        $fromDay = $from->setTime(0, 0);
+        $toDay = $to->setTime(0, 0);
+        $winnersByDay = [];
+
+        foreach ($candidates as $candidate) {
+            $windowFrom = $this->dateValue($candidate['window_from'] ?? null);
+            $windowTo = $this->dateValue($candidate['window_to'] ?? null);
+            if (null === $windowFrom || null === $windowTo || $windowFrom > $toDay || $windowTo < $fromDay) {
+                continue;
+            }
+
+            $cursor = $windowFrom > $fromDay ? $windowFrom : $fromDay;
+            $lastDay = $windowTo < $toDay ? $windowTo : $toDay;
+            for (; $cursor <= $lastDay; $cursor = $cursor->modify('+1 day')) {
+                $day = $cursor->format('Y-m-d');
+                $key = $this->coverageKey($candidate, $day);
+                $current = $winnersByDay[$key] ?? null;
+                if (null === $current || $this->isNewer($candidate, $current)) {
+                    $winnersByDay[$key] = $candidate;
+                }
+            }
+        }
+
+        $selected = [];
+        foreach ($winnersByDay as $key => $candidate) {
+            $day = substr((string) $key, -10);
+            $id = (string) $candidate['id'];
+            $selected[$id] ??= $candidate + ['selected_dates' => []];
+            $selected[$id]['selected_dates'][$day] = $day;
+        }
+
+        $rows = array_values(array_map(static function (array $row): array {
+            $selectedDates = array_values($row['selected_dates']);
+            sort($selectedDates);
+            $row['selected_dates'] = $selectedDates;
+
+            return $row;
+        }, $selected));
+
+        usort($rows, fn (array $left, array $right): int => $this->compareForDisplay($left, $right));
+
+        return $rows;
+    }
+
+    /**
+     * @param RawRow $row
+     */
+    private function coverageKey(array $row, string $day): string
+    {
+        return implode('|', [
+            (string) ($row['company_id'] ?? ''),
+            (string) ($row['shop_ref'] ?? ''),
+            $day,
+        ]);
+    }
+
+    /**
+     * @param RawRow $candidate
+     * @param RawRow $current
+     */
+    private function isNewer(array $candidate, array $current): bool
+    {
+        foreach (['fetched_at', 'created_at', 'id'] as $field) {
+            $left = $this->comparableValue($candidate[$field] ?? null);
+            $right = $this->comparableValue($current[$field] ?? null);
+            if ($left === $right) {
+                continue;
+            }
+
+            return $left > $right;
+        }
+
+        return false;
+    }
+
+    /**
+     * @param RawRow $left
+     * @param RawRow $right
+     */
+    private function compareForDisplay(array $left, array $right): int
+    {
+        foreach (['company_id', 'shop_ref', 'window_from', 'window_to', 'fetched_at', 'created_at', 'id'] as $field) {
+            $leftValue = $this->comparableValue($left[$field] ?? null);
+            $rightValue = $this->comparableValue($right[$field] ?? null);
+            if ($leftValue === $rightValue) {
+                continue;
+            }
+
+            return $leftValue <=> $rightValue;
+        }
+
+        return 0;
+    }
+
+    private function dateValue(mixed $value): ?\DateTimeImmutable
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return \DateTimeImmutable::createFromInterface($value)->setTime(0, 0);
+        }
+
+        if (!is_scalar($value)) {
+            return null;
+        }
+
+        $date = \DateTimeImmutable::createFromFormat('!Y-m-d', substr(trim((string) $value), 0, 10));
+
+        return false === $date ? null : $date;
+    }
+
+    private function comparableValue(mixed $value): string
+    {
+        if ($value instanceof \DateTimeInterface) {
+            return $value->format('Y-m-d H:i:s.u');
+        }
+
+        return trim((string) $value);
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualCompareCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualCompareCommand.php
@@ -9,6 +9,7 @@ use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayRawAggregator;
 use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Infrastructure\Query\OzonAccrualRawRecordQuery;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Console\Attribute\AsCommand;
 use Symfony\Component\Console\Command\Command;
@@ -37,6 +38,7 @@ final class OzonAccrualCompareCommand extends Command
         private readonly Connection $connection,
         private readonly RawStorageFacade $rawStorageFacade,
         private readonly OzonAccrualByDayRawAggregator $byDayRawAggregator,
+        private readonly OzonAccrualRawRecordQuery $rawRecordQuery,
     ) {
         parent::__construct();
     }
@@ -72,9 +74,9 @@ final class OzonAccrualCompareCommand extends Command
         $this->printCanonicalSummary($io, $companyId, $from, $to);
         $rawRecords = $this->rawRecords($companyId, $resourceType, $from, $to, $rawLimit);
         $this->printRawRecords($io, $rawRecords);
-        $this->printRawStructureSummary($io, $companyId, $rawRecords, $rawRowLimit);
+        $this->printRawStructureSummary($io, $companyId, $rawRecords, $rawRowLimit, $from, $to);
         if (OzonResourceType::ACCRUAL_BY_DAY === $resourceType) {
-            $aggregate = $this->byDayRawAggregator->aggregate($this->rawRows($companyId, $rawRecords, $rawRowLimit));
+            $aggregate = $this->byDayRawAggregator->aggregate($this->rawRows($companyId, $rawRecords, $rawRowLimit, $from, $to));
             $this->printByDayAggregate($io, $aggregate);
             $this->printDailyComparison($io, $aggregate, $this->canonicalDailyNetRows($companyId, $from, $to));
         }
@@ -169,6 +171,10 @@ final class OzonAccrualCompareCommand extends Command
         \DateTimeImmutable $to,
         int $limit,
     ): array {
+        if (OzonResourceType::ACCRUAL_BY_DAY === $resourceType) {
+            return $this->rawRecordQuery->latestCoverageRows($companyId, null, $from, $to, $limit);
+        }
+
         return $this->connection->fetchAllAssociative(
             sprintf(
                 'SELECT r.id,
@@ -225,8 +231,14 @@ final class OzonAccrualCompareCommand extends Command
     /**
      * @param list<array<string, mixed>> $rawRecords
      */
-    private function printRawStructureSummary(SymfonyStyle $io, string $companyId, array $rawRecords, int $rowLimit): void
-    {
+    private function printRawStructureSummary(
+        SymfonyStyle $io,
+        string $companyId,
+        array $rawRecords,
+        int $rowLimit,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): void {
         if ([] === $rawRecords) {
             return;
         }
@@ -238,12 +250,17 @@ final class OzonAccrualCompareCommand extends Command
 
         foreach ($rawRecords as $rawRecord) {
             $recordRows = 0;
+            $selectedDates = $this->selectedDateSet($rawRecord);
             foreach ($this->rawStorageFacade->read((string) $rawRecord['id'], $companyId) as $row) {
                 if ($recordRows >= $rowLimit) {
                     break;
                 }
 
                 ++$recordRows;
+                if (!$this->rowDateInWindow($row, $from, $to, $selectedDates)) {
+                    continue;
+                }
+
                 ++$scannedRows;
 
                 foreach ($row as $key => $value) {
@@ -320,19 +337,66 @@ final class OzonAccrualCompareCommand extends Command
      *
      * @return \Generator<int, array<string, mixed>>
      */
-    private function rawRows(string $companyId, array $rawRecords, int $rowLimit): \Generator
-    {
+    private function rawRows(
+        string $companyId,
+        array $rawRecords,
+        int $rowLimit,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): \Generator {
         foreach ($rawRecords as $rawRecord) {
             $recordRows = 0;
+            $selectedDates = $this->selectedDateSet($rawRecord);
             foreach ($this->rawStorageFacade->read((string) $rawRecord['id'], $companyId) as $row) {
                 if ($recordRows >= $rowLimit) {
                     break;
                 }
 
                 ++$recordRows;
+                if (!$this->rowDateInWindow($row, $from, $to, $selectedDates)) {
+                    continue;
+                }
+
                 yield $row;
             }
         }
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     */
+    private function rowDateInWindow(array $row, \DateTimeImmutable $from, \DateTimeImmutable $to, array $selectedDates): bool
+    {
+        $date = trim((string) ($row['date'] ?? ''));
+        if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+            return [] === $selectedDates;
+        }
+
+        if ([] !== $selectedDates) {
+            return isset($selectedDates[$date]);
+        }
+
+        return $date >= $from->format('Y-m-d') && $date <= $to->format('Y-m-d');
+    }
+
+    /**
+     * @param array<string, mixed> $rawRecord
+     *
+     * @return array<string, true>
+     */
+    private function selectedDateSet(array $rawRecord): array
+    {
+        $dates = $rawRecord['selected_dates'] ?? [];
+        if (!is_array($dates)) {
+            return [];
+        }
+
+        $set = [];
+        foreach ($dates as $date) {
+            $set[(string) $date] = true;
+        }
+
+        return $set;
     }
 
     private function printByDayAggregate(SymfonyStyle $io, OzonAccrualByDayRawAggregate $aggregate): void

--- a/site/src/Ingestion/Command/OzonAccrualNormalizeStoredCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualNormalizeStoredCommand.php
@@ -8,15 +8,13 @@ use App\Ingestion\Application\Action\NormalizeRawRecordAction;
 use App\Ingestion\Application\Action\RecordNormalizationIssueAction;
 use App\Ingestion\Application\Command\NormalizeRawRecordCommand;
 use App\Ingestion\Application\Command\RecordNormalizationIssueCommand;
-use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Entity\IngestRawRecord;
-use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\NormalizationIssueKind;
 use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Infrastructure\Query\OzonAccrualRawRecordQuery;
 use App\Ingestion\Message\NormalizeRawRecordMessage;
 use App\Ingestion\Repository\IngestRawRecordRepository;
 use App\Ingestion\Repository\NormalizationIssueRepository;
-use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -42,6 +40,7 @@ final class OzonAccrualNormalizeStoredCommand extends Command
         private readonly MessageBusInterface $messageBus,
         private readonly NormalizeRawRecordAction $normalizeRawRecordAction,
         private readonly RecordNormalizationIssueAction $recordNormalizationIssueAction,
+        private readonly OzonAccrualRawRecordQuery $rawRecordQuery,
     ) {
         parent::__construct();
     }
@@ -126,18 +125,6 @@ final class OzonAccrualNormalizeStoredCommand extends Command
         int $limit,
         bool $includeDone,
     ): array {
-        $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
-        $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
-        $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
-        $windowTo = sprintf('COALESCE(j.window_to, j.window_from, %s, %s, DATE(r.fetched_at))', $externalWindowTo, $externalWindowFrom);
-        $conditions = [
-            'r.company_id = :companyId',
-            'r.source = :source',
-            'r.resource_type = :resourceType',
-            'r.normalization_status IN (:statuses)',
-            sprintf('%s <= :toDate', $windowFrom),
-            sprintf('%s >= :fromDate', $windowTo),
-        ];
         $statuses = [
             RawNormalizationStatus::SKIPPED->value,
             RawNormalizationStatus::FAILED->value,
@@ -145,48 +132,8 @@ final class OzonAccrualNormalizeStoredCommand extends Command
         if ($includeDone) {
             $statuses[] = RawNormalizationStatus::DONE->value;
         }
-        $params = [
-            'companyId' => $companyId,
-            'source' => IngestSource::OZON->value,
-            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
-            'statuses' => $statuses,
-            'fromDate' => $from->format('Y-m-d'),
-            'toDate' => $to->format('Y-m-d'),
-        ];
-        $types = [
-            'statuses' => ArrayParameterType::STRING,
-        ];
 
-        if (null !== $shopRef && '' !== $shopRef) {
-            $conditions[] = 'r.shop_ref = :shopRef';
-            $params['shopRef'] = $shopRef;
-        }
-
-        return $this->connection->fetchAllAssociative(
-            sprintf(
-                'SELECT r.id,
-                        r.external_id,
-                        r.shop_ref,
-                        r.fetched_at,
-                        r.byte_size,
-                        r.normalization_status,
-                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_from,
-                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_to
-                 FROM ingest_raw_records r
-                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
-                 WHERE %s
-                 ORDER BY %s ASC, %s ASC, r.fetched_at ASC, r.created_at ASC
-                 LIMIT %d',
-                $windowFrom,
-                $windowTo,
-                implode(' AND ', $conditions),
-                $windowFrom,
-                $windowTo,
-                $limit,
-            ),
-            $params,
-            $types,
-        );
+        return $this->rawRecordQuery->latestCoverageRows($companyId, $shopRef, $from, $to, $limit, $statuses);
     }
 
     /**

--- a/site/src/Ingestion/Command/OzonAccrualPreviewNormalizationCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualPreviewNormalizationCommand.php
@@ -6,9 +6,9 @@ namespace App\Ingestion\Command;
 
 use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayPreviewMapper;
 use App\Ingestion\Application\Source\Ozon\OzonAccrualPreviewTransaction;
-use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Infrastructure\Query\OzonAccrualRawRecordQuery;
 use Doctrine\DBAL\ArrayParameterType;
 use Doctrine\DBAL\Connection;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -34,6 +34,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
         private readonly Connection $connection,
         private readonly RawStorageFacade $rawStorageFacade,
         private readonly OzonAccrualByDayPreviewMapper $previewMapper,
+        private readonly OzonAccrualRawRecordQuery $rawRecordQuery,
     ) {
         parent::__construct();
     }
@@ -106,32 +107,7 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
      */
     private function rawRecords(string $companyId, \DateTimeImmutable $from, \DateTimeImmutable $to, int $limit): array
     {
-        return $this->connection->fetchAllAssociative(
-            sprintf(
-                'SELECT r.id,
-                        r.resource_type,
-                        r.external_id,
-                        r.fetched_at,
-                        r.byte_size,
-                        r.normalization_status
-                 FROM ingest_raw_records r
-                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
-                 WHERE r.company_id = :companyId
-                   AND r.source = :source
-                   AND r.resource_type = :resourceType
-                   AND (j.id IS NULL OR j.window_from IS NULL OR j.window_to IS NULL OR (j.window_from <= :toDate AND j.window_to >= :fromDate))
-                 ORDER BY r.fetched_at DESC, r.created_at DESC
-                 LIMIT %d',
-                $limit,
-            ),
-            [
-                'companyId' => $companyId,
-                'source' => IngestSource::OZON->value,
-                'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
-                'fromDate' => $from->format('Y-m-d'),
-                'toDate' => $to->format('Y-m-d'),
-            ],
-        );
+        return $this->rawRecordQuery->latestCoverageRows($companyId, null, $from, $to, $limit);
     }
 
     /**
@@ -172,13 +148,14 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
     ): \Generator {
         foreach ($rawRecords as $rawRecord) {
             $recordRows = 0;
+            $selectedDates = $this->selectedDateSet($rawRecord);
             foreach ($this->rawStorageFacade->read((string) $rawRecord['id'], $companyId) as $row) {
                 if ($recordRows >= $rowLimit) {
                     break;
                 }
 
                 ++$recordRows;
-                if (!$this->rowDateInWindow($row, $from, $to)) {
+                if (!$this->rowDateInWindow($row, $from, $to, $selectedDates)) {
                     continue;
                 }
 
@@ -190,14 +167,38 @@ final class OzonAccrualPreviewNormalizationCommand extends Command
     /**
      * @param array<string, mixed> $row
      */
-    private function rowDateInWindow(array $row, \DateTimeImmutable $from, \DateTimeImmutable $to): bool
+    private function rowDateInWindow(array $row, \DateTimeImmutable $from, \DateTimeImmutable $to, array $selectedDates): bool
     {
         $date = trim((string) ($row['date'] ?? ''));
         if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
             return false;
         }
 
+        if ([] !== $selectedDates) {
+            return isset($selectedDates[$date]);
+        }
+
         return $date >= $from->format('Y-m-d') && $date <= $to->format('Y-m-d');
+    }
+
+    /**
+     * @param array<string, mixed> $rawRecord
+     *
+     * @return array<string, true>
+     */
+    private function selectedDateSet(array $rawRecord): array
+    {
+        $dates = $rawRecord['selected_dates'] ?? [];
+        if (!is_array($dates)) {
+            return [];
+        }
+
+        $set = [];
+        foreach ($dates as $date) {
+            $set[(string) $date] = true;
+        }
+
+        return $set;
     }
 
     /**

--- a/site/src/Ingestion/Command/OzonAccrualRefreshFinancialVerificationCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualRefreshFinancialVerificationCommand.php
@@ -18,6 +18,7 @@ use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\NormalizationIssueKind;
 use App\Ingestion\Enum\RawNormalizationStatus;
 use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Infrastructure\Query\OzonAccrualRawRecordQuery;
 use App\Ingestion\Repository\FinancialTransactionRepository;
 use App\Ingestion\Repository\IngestRawRecordRepository;
 use App\Ingestion\Repository\NormalizationIssueRepository;
@@ -56,6 +57,7 @@ final class OzonAccrualRefreshFinancialVerificationCommand extends Command
         private readonly RawStorageFacade $rawStorageFacade,
         private readonly OzonAccrualByDayPreviewMapper $previewMapper,
         private readonly FinancialTransactionRepository $transactionRepository,
+        private readonly OzonAccrualRawRecordQuery $rawRecordQuery,
     ) {
         parent::__construct();
     }
@@ -183,10 +185,6 @@ final class OzonAccrualRefreshFinancialVerificationCommand extends Command
         int $limit,
         bool $includeDone,
     ): array {
-        $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
-        $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
-        $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
-        $windowTo = sprintf('COALESCE(j.window_to, j.window_from, %s, %s, DATE(r.fetched_at))', $externalWindowTo, $externalWindowFrom);
         $statuses = [
             RawNormalizationStatus::PENDING->value,
             RawNormalizationStatus::SKIPPED->value,
@@ -196,66 +194,34 @@ final class OzonAccrualRefreshFinancialVerificationCommand extends Command
             $statuses[] = RawNormalizationStatus::DONE->value;
         }
 
-        $conditions = [
-            'r.source = :source',
-            'r.resource_type = :resourceType',
-            'r.normalization_status IN (:statuses)',
-            sprintf('%s <= :toDate', $windowFrom),
-            sprintf('%s >= :fromDate', $windowTo),
-        ];
-        $params = [
-            'source' => IngestSource::OZON->value,
-            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
-            'statuses' => $statuses,
-            'fromDate' => $from->format('Y-m-d'),
-            'toDate' => $to->format('Y-m-d'),
-        ];
-        $types = ['statuses' => ArrayParameterType::STRING];
+        $rows = $this->rawRecordQuery->latestCoverageRows($companyId, $shopRef, $from, $to, 0, $statuses);
+        usort($rows, static fn (array $left, array $right): int => [
+            self::statusSort((string) $left['normalization_status']),
+            (string) $left['window_from'],
+            (string) $left['window_to'],
+            (string) $left['company_id'],
+            (string) $left['shop_ref'],
+            (string) $left['fetched_at'],
+        ] <=> [
+            self::statusSort((string) $right['normalization_status']),
+            (string) $right['window_from'],
+            (string) $right['window_to'],
+            (string) $right['company_id'],
+            (string) $right['shop_ref'],
+            (string) $right['fetched_at'],
+        ]);
 
-        if (null !== $companyId) {
-            $conditions[] = 'r.company_id = :companyId';
-            $params['companyId'] = $companyId;
-        }
-        if (null !== $shopRef && '' !== $shopRef) {
-            $conditions[] = 'r.shop_ref = :shopRef';
-            $params['shopRef'] = $shopRef;
-        }
+        return array_slice($rows, 0, $limit);
+    }
 
-        return $this->connection->fetchAllAssociative(
-            sprintf(
-                'SELECT r.company_id,
-                        r.id,
-                        r.external_id,
-                        r.shop_ref,
-                        r.fetched_at,
-                        r.byte_size,
-                        r.normalization_status,
-                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_from,
-                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_to
-                 FROM ingest_raw_records r
-                 LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
-                 WHERE %s
-                 ORDER BY CASE r.normalization_status
-                              WHEN \'pending\' THEN 0
-                              WHEN \'failed\' THEN 1
-                              WHEN \'skipped\' THEN 2
-                              ELSE 3
-                          END ASC,
-                          %s ASC,
-                          %s ASC,
-                          r.fetched_at ASC,
-                          r.created_at ASC
-                 LIMIT %d',
-                $windowFrom,
-                $windowTo,
-                implode(' AND ', $conditions),
-                $windowFrom,
-                $windowTo,
-                $limit,
-            ),
-            $params,
-            $types,
-        );
+    private static function statusSort(string $status): int
+    {
+        return match ($status) {
+            RawNormalizationStatus::PENDING->value => 0,
+            RawNormalizationStatus::FAILED->value => 1,
+            RawNormalizationStatus::SKIPPED->value => 2,
+            default => 3,
+        };
     }
 
     /**
@@ -598,7 +564,7 @@ final class OzonAccrualRefreshFinancialVerificationCommand extends Command
 
     /**
      * @param list<array<string, mixed>> $rows
-     * @param array<string, string>      $ids
+     * @param array<string, string> $ids
      *
      * @return array<string, array<string, string>>
      */

--- a/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/CoverageQuery.php
@@ -55,7 +55,7 @@ final class CoverageQuery
                 'COUNT(DISTINCT r.id) AS raw_count',
                 'COUNT(DISTINCT ft.id) AS tx_count',
                 'COUNT(DISTINCT ni.id) AS issue_count',
-                'MAX(r.fetched_at) AS last_fetched_at',
+                'MAX(GREATEST(r.fetched_at, COALESCE(r.last_seen_at, r.fetched_at))) AS last_fetched_at',
             )
             ->from('ingest_raw_records', 'r')
             ->leftJoin(

--- a/site/src/Ingestion/Infrastructure/Query/OzonAccrualProjectionHealthQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/OzonAccrualProjectionHealthQuery.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace App\Ingestion\Infrastructure\Query;
 
-use App\Ingestion\Application\Source\Ozon\OzonResourceType;
 use App\Ingestion\Enum\IngestSource;
 use App\Ingestion\Enum\RawNormalizationStatus;
 use Doctrine\DBAL\ArrayParameterType;
@@ -12,8 +11,10 @@ use Doctrine\DBAL\Connection;
 
 final readonly class OzonAccrualProjectionHealthQuery
 {
-    public function __construct(private Connection $connection)
-    {
+    public function __construct(
+        private Connection $connection,
+        private OzonAccrualRawRecordQuery $rawRecordQuery,
+    ) {
     }
 
     /**
@@ -27,142 +28,253 @@ final readonly class OzonAccrualProjectionHealthQuery
         int $limit,
         bool $problemsOnly,
     ): array {
-        $externalWindowFrom = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
-        $externalWindowTo = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
-        $windowFrom = sprintf('COALESCE(j.window_from, %s, DATE(r.fetched_at))', $externalWindowFrom);
-        $windowTo = sprintf('COALESCE(j.window_to, j.window_from, %s, %s, DATE(r.fetched_at))', $externalWindowTo, $externalWindowFrom);
-
-        $conditions = [
-            'r.source = :source',
-            'r.resource_type = :resourceType',
-            sprintf('%s <= :toDate', $windowFrom),
-            sprintf('%s >= :fromDate', $windowTo),
-        ];
-        $params = [
-            'source' => IngestSource::OZON->value,
-            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
-            'fromDate' => $from->format('Y-m-d'),
-            'toDate' => $to->format('Y-m-d'),
-            'doneStatus' => RawNormalizationStatus::DONE->value,
-        ];
-
-        if (null !== $companyId) {
-            $conditions[] = 'r.company_id = :companyId';
-            $params['companyId'] = $companyId;
+        $rows = $this->rawRecordQuery->latestCoverageRows($companyId, $shopRef, $from, $to, 0);
+        if ([] === $rows) {
+            return [];
         }
 
-        if (null !== $shopRef) {
-            $conditions[] = 'r.shop_ref = :shopRef';
-            $params['shopRef'] = $shopRef;
+        $details = $this->projectionDetails($rows);
+        $result = [];
+        foreach ($rows as $row) {
+            $rawId = (string) $row['id'];
+            $tx = $details['tx'][$rawId] ?? ['tx_count' => 0, 'last_tx_updated_at' => null];
+            $directRawTxCount = (int) ($details['direct'][$rawId] ?? 0);
+            $openIssues = (int) ($details['issues'][$rawId] ?? 0);
+            $needsNormalization = RawNormalizationStatus::DONE->value !== (string) $row['normalization_status']
+                || 0 === (int) $tx['tx_count']
+                || 0 === $directRawTxCount
+                || $openIssues > 0;
+
+            if ($problemsOnly && !$needsNormalization) {
+                continue;
+            }
+
+            $result[] = [
+                'company_id' => (string) $row['company_id'],
+                'shop_ref' => (string) $row['shop_ref'],
+                'raw_id' => $rawId,
+                'external_id' => (string) $row['external_id'],
+                'normalization_status' => (string) $row['normalization_status'],
+                'fetched_at' => $row['fetched_at'],
+                'last_seen_at' => $row['last_seen_at'] ?? null,
+                'raw_updated_at' => $row['raw_updated_at'] ?? null,
+                'window_from' => (string) $row['window_from'],
+                'window_to' => (string) $row['window_to'],
+                'tx_count' => (int) $tx['tx_count'],
+                'direct_raw_tx_count' => $directRawTxCount,
+                'last_tx_updated_at' => $tx['last_tx_updated_at'],
+                'open_issues' => $openIssues,
+                'needs_normalization' => $needsNormalization ? 1 : 0,
+            ];
         }
 
-        $problemPredicate = '(
-            r.normalization_status <> :doneStatus
-            OR COALESCE(tx.tx_count, 0) = 0
-            OR COALESCE(direct_tx.direct_raw_tx_count, 0) = 0
-            OR COALESCE(issues.open_issues, 0) > 0
-        )';
+        usort($result, static fn (array $left, array $right): int => [
+            -(int) $left['needs_normalization'],
+            (string) $left['window_from'],
+            (string) $left['window_to'],
+            (string) $left['company_id'],
+            (string) $left['shop_ref'],
+            (string) $left['fetched_at'],
+        ] <=> [
+            -(int) $right['needs_normalization'],
+            (string) $right['window_from'],
+            (string) $right['window_to'],
+            (string) $right['company_id'],
+            (string) $right['shop_ref'],
+            (string) $right['fetched_at'],
+        ]);
 
-        $problemFilter = $problemsOnly ? sprintf('AND %s', $problemPredicate) : '';
+        return array_slice($result, 0, $limit);
+    }
 
-        /** @var list<array<string, mixed>> $rows */
+    /**
+     * @param list<array<string, mixed>> $rawRows
+     *
+     * @return array{tx: array<string, array{tx_count: int, last_tx_updated_at: mixed}>, direct: array<string, int>, issues: array<string, int>}
+     */
+    private function projectionDetails(array $rawRows): array
+    {
+        $rawIds = array_values(array_unique(array_map(static fn (array $row): string => (string) $row['id'], $rawRows)));
+
+        return [
+            'tx' => $this->txCountsByWindow($rawRows),
+            'direct' => $this->directRawTxCounts($rawIds),
+            'issues' => $this->openIssueCounts($rawIds),
+        ];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRows
+     *
+     * @return array<string, array{tx_count: int, last_tx_updated_at: mixed}>
+     */
+    private function txCountsByWindow(array $rawRows): array
+    {
+        $params = ['source' => IngestSource::OZON->value];
+        $values = $this->rawDateValues($rawRows, $params);
+        if ('' === $values) {
+            return [];
+        }
+
         $rows = $this->connection->fetchAllAssociative(
             sprintf(
-                "WITH raw AS (
-                    SELECT *
-                    FROM (
-                        SELECT r.company_id,
-                               r.shop_ref,
-                               r.id AS raw_id,
-                               r.external_id,
-                               r.normalization_status,
-                               r.fetched_at,
-                               r.last_seen_at,
-                               r.updated_at AS raw_updated_at,
-                               %s AS window_from,
-                               %s AS window_to,
-                               ROW_NUMBER() OVER (
-                                   PARTITION BY r.company_id, r.shop_ref, r.external_id
-                                   ORDER BY r.fetched_at DESC, r.id DESC
-                               ) AS raw_rank
-                        FROM ingest_raw_records r
-                        LEFT JOIN ingest_sync_jobs j ON j.id::text = r.sync_job_id AND j.company_id = r.company_id
-                        WHERE %s
-                    ) ranked_raw
-                    WHERE raw_rank = 1
-                ),
-                tx AS (
-                    SELECT raw.raw_id,
-                           COUNT(ft.id) AS tx_count,
-                           MAX(ft.updated_at) AS last_tx_updated_at
-                    FROM raw
-                    LEFT JOIN ingest_financial_transactions ft
-                      ON ft.company_id = raw.company_id
-                     AND ft.shop_ref = raw.shop_ref
-                     AND ft.source = :source
-                     AND ft.external_id LIKE 'ozon:accrual-by-day:%%'
-                     AND ft.occurred_at >= raw.window_from
-                     AND ft.occurred_at < raw.window_to + INTERVAL '1 day'
-                    GROUP BY raw.raw_id
-                ),
-                direct_tx AS (
-                    SELECT raw.raw_id,
-                           COUNT(ft.id) AS direct_raw_tx_count
-                    FROM raw
-                    LEFT JOIN ingest_financial_transactions ft
-                      ON ft.company_id = raw.company_id
-                     AND ft.raw_record_id = raw.raw_id
-                     AND ft.source = :source
-                    GROUP BY raw.raw_id
-                ),
-                issues AS (
-                    SELECT raw.raw_id,
-                           COUNT(i.id) FILTER (WHERE i.resolved_at IS NULL) AS open_issues
-                    FROM raw
-                    LEFT JOIN ingest_normalization_issues i
-                      ON i.company_id = raw.company_id
-                     AND i.raw_record_id = raw.raw_id
-                    GROUP BY raw.raw_id
-                )
-                SELECT r.company_id,
-                       r.shop_ref,
-                       r.raw_id,
-                       r.external_id,
-                       r.normalization_status,
-                       r.fetched_at,
-                       r.last_seen_at,
-                       r.raw_updated_at,
-                       TO_CHAR(r.window_from, 'YYYY-MM-DD') AS window_from,
-                       TO_CHAR(r.window_to, 'YYYY-MM-DD') AS window_to,
-                       COALESCE(tx.tx_count, 0) AS tx_count,
-                       COALESCE(direct_tx.direct_raw_tx_count, 0) AS direct_raw_tx_count,
-                       tx.last_tx_updated_at,
-                       COALESCE(issues.open_issues, 0) AS open_issues,
-                       CASE WHEN %s THEN 1 ELSE 0 END AS needs_normalization
-                FROM raw r
-                LEFT JOIN tx ON tx.raw_id = r.raw_id
-                LEFT JOIN direct_tx ON direct_tx.raw_id = r.raw_id
-                LEFT JOIN issues ON issues.raw_id = r.raw_id
-                WHERE TRUE
-                %s
-                ORDER BY needs_normalization DESC,
-                         r.window_from ASC,
-                         r.window_to ASC,
-                         r.company_id ASC,
-                         r.shop_ref ASC,
-                         r.fetched_at ASC
-                LIMIT %d",
-                $windowFrom,
-                $windowTo,
-                implode(' AND ', $conditions),
-                $problemPredicate,
-                $problemFilter,
-                $limit,
+                "WITH raw(raw_id, company_id, shop_ref, selected_date) AS (VALUES %s)
+                 SELECT raw.raw_id,
+                        COUNT(ft.id) AS tx_count,
+                        MAX(ft.updated_at) AS last_tx_updated_at
+                 FROM raw
+                 LEFT JOIN ingest_financial_transactions ft
+                   ON ft.company_id = raw.company_id
+                  AND ft.shop_ref = raw.shop_ref
+                  AND ft.source = :source
+                  AND ft.external_id LIKE 'ozon:accrual-by-day:%%'
+                  AND ft.occurred_at >= raw.selected_date
+                  AND ft.occurred_at < raw.selected_date + INTERVAL '1 day'
+                 GROUP BY raw.raw_id",
+                $values,
             ),
             $params,
         );
 
-        return $rows;
+        $indexed = [];
+        foreach ($rows as $row) {
+            $indexed[(string) $row['raw_id']] = [
+                'tx_count' => (int) $row['tx_count'],
+                'last_tx_updated_at' => $row['last_tx_updated_at'] ?? null,
+            ];
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * @param list<string> $rawIds
+     *
+     * @return array<string, int>
+     */
+    private function directRawTxCounts(array $rawIds): array
+    {
+        if ([] === $rawIds) {
+            return [];
+        }
+
+        $rows = $this->connection->executeQuery(
+            'SELECT raw_record_id, COUNT(id) AS tx_count
+             FROM ingest_financial_transactions
+             WHERE source = :source
+               AND raw_record_id IN (:rawIds)
+             GROUP BY raw_record_id',
+            [
+                'source' => IngestSource::OZON->value,
+                'rawIds' => $rawIds,
+            ],
+            [
+                'rawIds' => ArrayParameterType::STRING,
+            ],
+        )->fetchAllAssociative();
+
+        $indexed = [];
+        foreach ($rows as $row) {
+            $indexed[(string) $row['raw_record_id']] = (int) $row['tx_count'];
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * @param list<string> $rawIds
+     *
+     * @return array<string, int>
+     */
+    private function openIssueCounts(array $rawIds): array
+    {
+        if ([] === $rawIds) {
+            return [];
+        }
+
+        $rows = $this->connection->executeQuery(
+            'SELECT raw_record_id, COUNT(id) FILTER (WHERE resolved_at IS NULL) AS open_issues
+             FROM ingest_normalization_issues
+             WHERE raw_record_id IN (:rawIds)
+             GROUP BY raw_record_id',
+            [
+                'rawIds' => $rawIds,
+            ],
+            [
+                'rawIds' => ArrayParameterType::STRING,
+            ],
+        )->fetchAllAssociative();
+
+        $indexed = [];
+        foreach ($rows as $row) {
+            $indexed[(string) $row['raw_record_id']] = (int) $row['open_issues'];
+        }
+
+        return $indexed;
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRows
+     * @param array<string, mixed> $params
+     */
+    private function rawDateValues(array $rawRows, array &$params): string
+    {
+        $values = [];
+        $index = 0;
+        foreach ($rawRows as $row) {
+            foreach ($this->selectedDates($row) as $date) {
+                $params[sprintf('rawId%d', $index)] = (string) $row['id'];
+                $params[sprintf('companyId%d', $index)] = (string) $row['company_id'];
+                $params[sprintf('shopRef%d', $index)] = (string) $row['shop_ref'];
+                $params[sprintf('selectedDate%d', $index)] = $date;
+                $values[] = sprintf(
+                    '(CAST(:rawId%d AS UUID), CAST(:companyId%d AS UUID), :shopRef%d, CAST(:selectedDate%d AS DATE))',
+                    $index,
+                    $index,
+                    $index,
+                    $index,
+                );
+                ++$index;
+            }
+        }
+
+        return implode(', ', $values);
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     *
+     * @return list<string>
+     */
+    private function selectedDates(array $row): array
+    {
+        $dates = [];
+        if (is_array($row['selected_dates'] ?? null)) {
+            foreach ($row['selected_dates'] as $date) {
+                $date = trim((string) $date);
+                if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+                    $dates[$date] = $date;
+                }
+            }
+        }
+
+        if ([] !== $dates) {
+            sort($dates);
+
+            return array_values($dates);
+        }
+
+        $from = \DateTimeImmutable::createFromFormat('!Y-m-d', substr((string) ($row['window_from'] ?? ''), 0, 10));
+        $to = \DateTimeImmutable::createFromFormat('!Y-m-d', substr((string) ($row['window_to'] ?? ''), 0, 10));
+        if (false === $from || false === $to || $from > $to) {
+            return [];
+        }
+
+        for ($cursor = $from; $cursor <= $to; $cursor = $cursor->modify('+1 day')) {
+            $dates[] = $cursor->format('Y-m-d');
+        }
+
+        return $dates;
     }
 
     /**

--- a/site/src/Ingestion/Infrastructure/Query/OzonAccrualRawRecordQuery.php
+++ b/site/src/Ingestion/Infrastructure/Query/OzonAccrualRawRecordQuery.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Infrastructure\Query;
+
+use App\Ingestion\Application\Source\Ozon\OzonAccrualRawCoverageSelector;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use Doctrine\DBAL\Connection;
+
+final readonly class OzonAccrualRawRecordQuery
+{
+    private const WINDOW_FROM_SQL = "substring(r.external_id from '^accrual-by-day:([0-9]{4}-[0-9]{2}-[0-9]{2}):[0-9]{4}-[0-9]{2}-[0-9]{2}$')::date";
+    private const WINDOW_TO_SQL = "substring(r.external_id from '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:([0-9]{4}-[0-9]{2}-[0-9]{2})$')::date";
+
+    public function __construct(
+        private Connection $connection,
+        private OzonAccrualRawCoverageSelector $coverageSelector,
+    ) {
+    }
+
+    /**
+     * @param list<string>|null $statuses
+     *
+     * @return list<array<string, mixed>>
+     */
+    public function latestCoverageRows(
+        ?string $companyId,
+        ?string $shopRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+        int $limit,
+        ?array $statuses = null,
+        int $offset = 0,
+    ): array {
+        $rows = $this->coverageSelector->selectLatest(
+            $this->candidateRows($companyId, $shopRef, $from, $to),
+            $from,
+            $to,
+        );
+
+        if (null !== $statuses) {
+            $statusMap = array_fill_keys($statuses, true);
+            $rows = array_values(array_filter(
+                $rows,
+                static fn (array $row): bool => isset($statusMap[(string) $row['normalization_status']]),
+            ));
+        }
+
+        if ($offset > 0) {
+            $rows = array_slice($rows, $offset);
+        }
+
+        return $limit > 0 ? array_slice($rows, 0, $limit) : $rows;
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    public function doneRawRecord(string $companyId, string $rawRecordId): ?array
+    {
+        $row = $this->connection->fetchAssociative(
+            sprintf(
+                'SELECT r.id,
+                        r.company_id,
+                        r.resource_type,
+                        r.external_id,
+                        r.shop_ref,
+                        r.fetched_at,
+                        r.last_seen_at,
+                        r.updated_at AS raw_updated_at,
+                        r.created_at,
+                        r.byte_size,
+                        r.normalization_status,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_from,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_to
+                 FROM ingest_raw_records r
+                 WHERE r.id = :rawRecordId
+                   AND r.company_id = :companyId
+                   AND r.source = :source
+                   AND r.resource_type = :resourceType
+                   AND r.normalization_status = :doneStatus
+                 LIMIT 1',
+                self::WINDOW_FROM_SQL,
+                self::WINDOW_TO_SQL,
+            ),
+            [
+                'rawRecordId' => $rawRecordId,
+                'companyId' => $companyId,
+                'source' => IngestSource::OZON->value,
+                'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+                'doneStatus' => RawNormalizationStatus::DONE->value,
+            ],
+        );
+
+        return false === $row ? null : $row;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function candidateRows(
+        ?string $companyId,
+        ?string $shopRef,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): array {
+        $conditions = [
+            'r.source = :source',
+            'r.resource_type = :resourceType',
+            'r.external_id ~ :externalIdPattern',
+            sprintf('%s <= :toDate', self::WINDOW_FROM_SQL),
+            sprintf('%s >= :fromDate', self::WINDOW_TO_SQL),
+        ];
+        $params = [
+            'source' => IngestSource::OZON->value,
+            'resourceType' => OzonResourceType::ACCRUAL_BY_DAY,
+            'externalIdPattern' => '^accrual-by-day:[0-9]{4}-[0-9]{2}-[0-9]{2}:[0-9]{4}-[0-9]{2}-[0-9]{2}$',
+            'fromDate' => $from->format('Y-m-d'),
+            'toDate' => $to->format('Y-m-d'),
+        ];
+
+        if (null !== $companyId) {
+            $conditions[] = 'r.company_id = :companyId';
+            $params['companyId'] = $companyId;
+        }
+
+        if (null !== $shopRef && '' !== $shopRef) {
+            $conditions[] = 'r.shop_ref = :shopRef';
+            $params['shopRef'] = $shopRef;
+        }
+
+        return $this->connection->fetchAllAssociative(
+            sprintf(
+                'SELECT r.id,
+                        r.company_id,
+                        r.resource_type,
+                        r.external_id,
+                        r.shop_ref,
+                        r.fetched_at,
+                        r.last_seen_at,
+                        r.updated_at AS raw_updated_at,
+                        r.created_at,
+                        r.byte_size,
+                        r.normalization_status,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_from,
+                        TO_CHAR(%s, \'YYYY-MM-DD\') AS window_to
+                 FROM ingest_raw_records r
+                 WHERE %s
+                 ORDER BY r.company_id ASC,
+                          r.shop_ref ASC,
+                          %s ASC,
+                          %s ASC,
+                          r.fetched_at ASC,
+                          r.created_at ASC',
+                self::WINDOW_FROM_SQL,
+                self::WINDOW_TO_SQL,
+                implode(' AND ', $conditions),
+                self::WINDOW_FROM_SQL,
+                self::WINDOW_TO_SQL,
+            ),
+            $params,
+        );
+    }
+}

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualRawCoverageSelectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonAccrualRawCoverageSelectorTest.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Ingestion\Application\Source\Ozon;
+
+use App\Ingestion\Application\Source\Ozon\OzonAccrualRawCoverageSelector;
+use PHPUnit\Framework\TestCase;
+
+final class OzonAccrualRawCoverageSelectorTest extends TestCase
+{
+    public function testLaterWeeklyRawSupersedesPreviouslyLoadedDailyTail(): void
+    {
+        $selector = new OzonAccrualRawCoverageSelector();
+
+        $rows = $selector->selectLatest([
+            $this->raw('old-22-23', 'accrual-by-day:2026-06-22:2026-06-23', '2026-06-22', '2026-06-23', '2026-06-24 10:25:18'),
+            $this->raw('old-24', 'accrual-by-day:2026-06-24:2026-06-24', '2026-06-24', '2026-06-24', '2026-06-25 03:00:04'),
+            $this->raw('old-25', 'accrual-by-day:2026-06-25:2026-06-25', '2026-06-25', '2026-06-25', '2026-06-26 03:00:02'),
+            $this->raw('old-26', 'accrual-by-day:2026-06-26:2026-06-26', '2026-06-26', '2026-06-26', '2026-06-27 03:00:03'),
+            $this->raw('old-27', 'accrual-by-day:2026-06-27:2026-06-27', '2026-06-27', '2026-06-27', '2026-06-28 03:00:05'),
+            $this->raw('old-28', 'accrual-by-day:2026-06-28:2026-06-28', '2026-06-28', '2026-06-28', '2026-06-29 03:00:03'),
+            $this->raw('new-22-28', 'accrual-by-day:2026-06-22:2026-06-28', '2026-06-22', '2026-06-28', '2026-06-29 20:39:25'),
+        ], new \DateTimeImmutable('2026-06-22'), new \DateTimeImmutable('2026-06-28'));
+
+        self::assertCount(1, $rows);
+        self::assertSame('new-22-28', $rows[0]['id']);
+        self::assertSame([
+            '2026-06-22',
+            '2026-06-23',
+            '2026-06-24',
+            '2026-06-25',
+            '2026-06-26',
+            '2026-06-27',
+            '2026-06-28',
+        ], $rows[0]['selected_dates']);
+    }
+
+    public function testNewerSingleDayRawCanPartiallySupersedeWeeklyRaw(): void
+    {
+        $selector = new OzonAccrualRawCoverageSelector();
+
+        $rows = $selector->selectLatest([
+            $this->raw('week', 'accrual-by-day:2026-06-22:2026-06-28', '2026-06-22', '2026-06-28', '2026-06-29 03:00:00'),
+            $this->raw('day-25', 'accrual-by-day:2026-06-25:2026-06-25', '2026-06-25', '2026-06-25', '2026-06-29 04:00:00'),
+        ], new \DateTimeImmutable('2026-06-22'), new \DateTimeImmutable('2026-06-28'));
+
+        self::assertCount(2, $rows);
+        self::assertSame('week', $rows[0]['id']);
+        self::assertSame(['2026-06-22', '2026-06-23', '2026-06-24', '2026-06-26', '2026-06-27', '2026-06-28'], $rows[0]['selected_dates']);
+        self::assertSame('day-25', $rows[1]['id']);
+        self::assertSame(['2026-06-25'], $rows[1]['selected_dates']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function raw(string $id, string $externalId, string $windowFrom, string $windowTo, string $fetchedAt): array
+    {
+        return [
+            'id' => $id,
+            'company_id' => 'company-1',
+            'shop_ref' => 'shop-1',
+            'external_id' => $externalId,
+            'normalization_status' => 'done',
+            'window_from' => $windowFrom,
+            'window_to' => $windowTo,
+            'fetched_at' => $fetchedAt,
+            'created_at' => $fetchedAt,
+        ];
+    }
+}


### PR DESCRIPTION
## Summary

Fixes Ozon accrual verification/replay behavior when raw windows overlap, for example when the latest 7 days were loaded first and a wider backfill was loaded later.

Root cause: preview/compare/replay commands selected every raw record overlapping the requested period, so old daily raw records and a newer weekly raw record could be read together. That doubled raw diagnostics for the overlapping days.

## Changes

- Add a shared Ozon accrual raw coverage selector that chooses the newest raw record per company/shop/day.
- Route Ozon accrual preview, compare, stored normalization, financial verification refresh, projection health, and category metadata refresh through that shared latest-coverage query.
- Filter raw row reads to the selected dates for partial coverage cases.
- Make coverage freshness use `last_seen_at` as well as `fetched_at`, so same-hash reloads are visible in coverage.
- Add a unit test for the exact daily-tail + newer-weekly overlap case.

## Scope

Only Ingestion code is changed. No PnL, legacy Marketplace, report formula, DB schema, queue, or cron changes.

## Validation

- `php -l` on changed PHP files: OK
- `bin/phpunit --testsuite unit --filter OzonAccrualRawCoverageSelectorTest`: OK
- `bin/console lint:container`: OK
- `composer test:unit`: OK, 1227 tests; existing suite still reports 1 warning and 1 deprecation
- scoped `php-cs-fixer` on changed files: OK

Global `composer cs:check` is still red because of existing style issues across unrelated project files; changed files pass scoped CS check.