### PR TITLE
[codex] Fix Ozon accrual by-day pagination

### DIFF
--- a/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
@@ -21,6 +21,7 @@ use Symfony\Component\Clock\ClockInterface;
 final readonly class OzonSellerReportConnector implements SourceConnectorInterface
 {
     private const INCREMENTAL_CONTINUATION_DELAY_SECONDS = 1;
+    private const MAX_ACCRUAL_BY_DAY_PAGES_PER_DAY = 100;
 
     public function __construct(
         private OzonAccrualClientInterface $accrualClient,
@@ -98,19 +99,15 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
         $apiMetadata = [];
 
         foreach ($this->eachDay($from, $to) as $date) {
-            $page = $this->accrualClient->fetchByDay(
-                $request->companyId,
-                $request->connectionRef,
-                $date,
-            );
+            $daily = $this->fetchAccrualByDayPages($request, $date);
 
-            if ([] !== $page->rows) {
-                array_push($rows, ...$page->rows);
+            if ([] !== $daily['rows']) {
+                array_push($rows, ...$daily['rows']);
             }
 
             $apiMetadata[] = [
                 'date' => $date->format('Y-m-d'),
-                'metadata' => $page->metadata,
+                'metadata' => $daily['metadata'],
             ];
         }
 
@@ -146,6 +143,72 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
             hasMore: $windowHasMore || $incrementalHasMore,
             continuationDelaySeconds: $incrementalHasMore ? self::INCREMENTAL_CONTINUATION_DELAY_SECONDS : null,
         );
+    }
+
+    /**
+     * @return array{rows: list<array<string, mixed>>, metadata: array<string, mixed>}
+     */
+    private function fetchAccrualByDayPages(PullRequest $request, \DateTimeImmutable $date): array
+    {
+        $rows = [];
+        $pages = [];
+        $seenLastIds = [];
+        $lastId = null;
+        $pageNumber = 1;
+
+        while (true) {
+            $page = $this->accrualClient->fetchByDay(
+                $request->companyId,
+                $request->connectionRef,
+                $date,
+                $lastId,
+            );
+
+            if ([] !== $page->rows) {
+                array_push($rows, ...$page->rows);
+            }
+
+            $nextLastId = null !== $page->nextPageToken && '' !== trim($page->nextPageToken)
+                ? trim($page->nextPageToken)
+                : null;
+
+            $pages[] = [
+                'page' => $pageNumber,
+                'lastId' => $lastId,
+                'nextLastId' => $nextLastId,
+                'rowCount' => \count($page->rows),
+                'metadata' => $page->metadata,
+            ];
+
+            if (!$page->hasMore) {
+                break;
+            }
+
+            if (null === $nextLastId) {
+                throw new \RuntimeException(sprintf('Ozon accrual by-day page for %s has more rows but no next last_id.', $date->format('Y-m-d')));
+            }
+
+            if (isset($seenLastIds[$nextLastId])) {
+                throw new \RuntimeException(sprintf('Ozon accrual by-day page for %s repeated last_id "%s".', $date->format('Y-m-d'), $nextLastId));
+            }
+
+            if ($pageNumber >= self::MAX_ACCRUAL_BY_DAY_PAGES_PER_DAY) {
+                throw new \RuntimeException(sprintf('Ozon accrual by-day page limit exceeded for %s.', $date->format('Y-m-d')));
+            }
+
+            $seenLastIds[$nextLastId] = true;
+            $lastId = $nextLastId;
+            ++$pageNumber;
+        }
+
+        return [
+            'rows' => $rows,
+            'metadata' => [
+                'pageCount' => \count($pages),
+                'rowCount' => \count($rows),
+                'pages' => $pages,
+            ],
+        ];
     }
 
     private function pullAccrualTypes(PullRequest $request): PullResult

--- a/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
+++ b/site/src/Ingestion/Application/Source/Ozon/OzonSellerReportConnector.php
@@ -21,7 +21,6 @@ use Symfony\Component\Clock\ClockInterface;
 final readonly class OzonSellerReportConnector implements SourceConnectorInterface
 {
     private const INCREMENTAL_CONTINUATION_DELAY_SECONDS = 1;
-    private const MAX_ACCRUAL_BY_DAY_PAGES_PER_DAY = 100;
 
     public function __construct(
         private OzonAccrualClientInterface $accrualClient,
@@ -96,19 +95,11 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
     {
         [$from, $to] = $this->resolveDailyWindow($request);
         $rows = [];
-        $apiMetadata = [];
 
         foreach ($this->eachDay($from, $to) as $date) {
-            $daily = $this->fetchAccrualByDayPages($request, $date);
+            $dailyRows = $this->fetchAccrualByDayPages($request, $date);
 
-            if ([] !== $daily['rows']) {
-                array_push($rows, ...$daily['rows']);
-            }
-
-            $apiMetadata[] = [
-                'date' => $date->format('Y-m-d'),
-                'metadata' => $daily['metadata'],
-            ];
+            array_push($rows, ...$dailyRows);
         }
 
         $rows = $this->sortRowsCanonically($rows);
@@ -135,7 +126,6 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
                     [
                         'windowFrom' => $from->format('Y-m-d'),
                         'windowTo' => $to->format('Y-m-d'),
-                        'apiMetadata' => $apiMetadata,
                     ],
                 ),
             ),
@@ -146,15 +136,13 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
     }
 
     /**
-     * @return array{rows: list<array<string, mixed>>, metadata: array<string, mixed>}
+     * @return list<array<string, mixed>>
      */
     private function fetchAccrualByDayPages(PullRequest $request, \DateTimeImmutable $date): array
     {
         $rows = [];
-        $pages = [];
         $seenLastIds = [];
         $lastId = null;
-        $pageNumber = 1;
 
         while (true) {
             $page = $this->accrualClient->fetchByDay(
@@ -172,43 +160,19 @@ final readonly class OzonSellerReportConnector implements SourceConnectorInterfa
                 ? trim($page->nextPageToken)
                 : null;
 
-            $pages[] = [
-                'page' => $pageNumber,
-                'lastId' => $lastId,
-                'nextLastId' => $nextLastId,
-                'rowCount' => \count($page->rows),
-                'metadata' => $page->metadata,
-            ];
-
-            if (!$page->hasMore) {
-                break;
-            }
-
             if (null === $nextLastId) {
-                throw new \RuntimeException(sprintf('Ozon accrual by-day page for %s has more rows but no next last_id.', $date->format('Y-m-d')));
+                break;
             }
 
             if (isset($seenLastIds[$nextLastId])) {
                 throw new \RuntimeException(sprintf('Ozon accrual by-day page for %s repeated last_id "%s".', $date->format('Y-m-d'), $nextLastId));
             }
 
-            if ($pageNumber >= self::MAX_ACCRUAL_BY_DAY_PAGES_PER_DAY) {
-                throw new \RuntimeException(sprintf('Ozon accrual by-day page limit exceeded for %s.', $date->format('Y-m-d')));
-            }
-
             $seenLastIds[$nextLastId] = true;
             $lastId = $nextLastId;
-            ++$pageNumber;
         }
 
-        return [
-            'rows' => $rows,
-            'metadata' => [
-                'pageCount' => \count($pages),
-                'rowCount' => \count($rows),
-                'pages' => $pages,
-            ],
-        ];
+        return $rows;
     }
 
     private function pullAccrualTypes(PullRequest $request): PullResult

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClient.php
@@ -93,8 +93,9 @@ final readonly class OzonAccrualClient implements OzonAccrualClientInterface
         $result = is_array($payload['result'] ?? null) ? $payload['result'] : [];
         $nextLastId = $lastIdPagination ? $this->stringValue($result['last_id'] ?? $payload['last_id'] ?? null) : null;
         $total = $this->intValue($result['total'] ?? $payload['total'] ?? null);
-        $hasMore = null !== $nextLastId
-            || (bool) ($result['has_next'] ?? $result['has_more'] ?? $payload['has_next'] ?? $payload['has_more'] ?? false);
+        $hasMore = $lastIdPagination
+            ? null !== $nextLastId
+            : (bool) ($result['has_next'] ?? $result['has_more'] ?? $payload['has_next'] ?? $payload['has_more'] ?? false);
 
         if (!$hasMore && !$lastIdPagination && $total > 0 && $pageSize > 0) {
             $hasMore = ($offset + \count($rows)) < $total;

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClient.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClient.php
@@ -46,14 +46,22 @@ final readonly class OzonAccrualClient implements OzonAccrualClientInterface
         string $companyId,
         string $connectionRef,
         \DateTimeImmutable $date,
+        ?string $lastId = null,
     ): OzonRawPage {
+        $json = [
+            'date' => $date->format('Y-m-d'),
+        ];
+
+        if (null !== $lastId && '' !== trim($lastId)) {
+            $json['last_id'] = trim($lastId);
+        }
+
         return $this->requestPage(
             companyId: $companyId,
             connectionRef: $connectionRef,
             endpoint: self::BY_DAY_ENDPOINT,
-            json: [
-                'date' => $date->format('Y-m-d'),
-            ],
+            json: $json,
+            lastIdPagination: true,
         );
     }
 
@@ -78,26 +86,32 @@ final readonly class OzonAccrualClient implements OzonAccrualClientInterface
         int $page = 1,
         int $pageSize = 0,
         int $offset = 0,
+        bool $lastIdPagination = false,
     ): OzonRawPage {
         $payload = $this->requestJson($companyId, $connectionRef, $endpoint, $json);
         $rows = $this->extractRows($payload);
         $result = is_array($payload['result'] ?? null) ? $payload['result'] : [];
+        $nextLastId = $lastIdPagination ? $this->stringValue($result['last_id'] ?? $payload['last_id'] ?? null) : null;
         $total = $this->intValue($result['total'] ?? $payload['total'] ?? null);
-        $hasMore = (bool) ($result['has_next'] ?? $result['has_more'] ?? $payload['has_next'] ?? $payload['has_more'] ?? false);
+        $hasMore = null !== $nextLastId
+            || (bool) ($result['has_next'] ?? $result['has_more'] ?? $payload['has_next'] ?? $payload['has_more'] ?? false);
 
-        if (!$hasMore && $total > 0 && $pageSize > 0) {
+        if (!$hasMore && !$lastIdPagination && $total > 0 && $pageSize > 0) {
             $hasMore = ($offset + \count($rows)) < $total;
         }
 
         return new OzonRawPage(
             rows: $rows,
             hasMore: $hasMore,
-            nextPageToken: $hasMore ? (string) ($page + 1) : null,
+            nextPageToken: $lastIdPagination ? $nextLastId : ($hasMore ? (string) ($page + 1) : null),
             metadata: [
                 'endpoint' => $endpoint,
                 'page' => $page,
                 'pageSize' => $pageSize,
                 'offset' => $offset,
+                'lastId' => $lastIdPagination && is_array($json) ? ($json['last_id'] ?? null) : null,
+                'nextLastId' => $nextLastId,
+                'rows' => \count($rows),
                 'total' => $total > 0 ? $total : null,
                 'resultKeys' => array_keys($result),
             ],
@@ -202,6 +216,17 @@ final readonly class OzonAccrualClient implements OzonAccrualClientInterface
         }
 
         return 0;
+    }
+
+    private function stringValue(mixed $value): ?string
+    {
+        if (!is_scalar($value)) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return '' !== $value ? $value : null;
     }
 
     /**

--- a/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientInterface.php
+++ b/site/src/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientInterface.php
@@ -19,6 +19,7 @@ interface OzonAccrualClientInterface
         string $companyId,
         string $connectionRef,
         \DateTimeImmutable $date,
+        ?string $lastId = null,
     ): OzonRawPage;
 
     public function fetchTypes(string $companyId, string $connectionRef): OzonRawPage;

--- a/site/tests/Integration/Ingestion/Fixtures/FakeOzonAccrualClient.php
+++ b/site/tests/Integration/Ingestion/Fixtures/FakeOzonAccrualClient.php
@@ -26,7 +26,7 @@ final class FakeOzonAccrualClient implements OzonAccrualClientInterface
         return new OzonRawPage(rows: [], hasMore: false);
     }
 
-    public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date): OzonRawPage
+    public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date, ?string $lastId = null): OzonRawPage
     {
         return new OzonRawPage(
             rows: [[

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
@@ -68,7 +68,7 @@ final class OzonSellerReportConnectorTest extends TestCase
                 throw new \LogicException('Not used.');
             }
 
-            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date): OzonRawPage
+            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date, ?string $lastId = null): OzonRawPage
             {
                 throw new \LogicException('Not used.');
             }
@@ -113,7 +113,7 @@ final class OzonSellerReportConnectorTest extends TestCase
                 throw new \LogicException('Not used.');
             }
 
-            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date): OzonRawPage
+            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date, ?string $lastId = null): OzonRawPage
             {
                 $this->dates[] = $date->format('Y-m-d');
 
@@ -151,11 +151,31 @@ final class OzonSellerReportConnectorTest extends TestCase
                     'apiMetadata' => [
                         [
                             'date' => '2026-06-01',
-                            'metadata' => ['endpoint' => '/v1/finance/accrual/by-day'],
+                            'metadata' => [
+                                'pageCount' => 1,
+                                'rowCount' => 0,
+                                'pages' => [[
+                                    'page' => 1,
+                                    'lastId' => null,
+                                    'nextLastId' => null,
+                                    'rowCount' => 0,
+                                    'metadata' => ['endpoint' => '/v1/finance/accrual/by-day'],
+                                ]],
+                            ],
                         ],
                         [
                             'date' => '2026-06-02',
-                            'metadata' => ['endpoint' => '/v1/finance/accrual/by-day'],
+                            'metadata' => [
+                                'pageCount' => 1,
+                                'rowCount' => 0,
+                                'pages' => [[
+                                    'page' => 1,
+                                    'lastId' => null,
+                                    'nextLastId' => null,
+                                    'rowCount' => 0,
+                                    'metadata' => ['endpoint' => '/v1/finance/accrual/by-day'],
+                                ]],
+                            ],
                         ],
                     ],
                 ],
@@ -178,7 +198,7 @@ final class OzonSellerReportConnectorTest extends TestCase
                 throw new \LogicException('Not used.');
             }
 
-            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date): OzonRawPage
+            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date, ?string $lastId = null): OzonRawPage
             {
                 $dateString = $date->format('Y-m-d');
                 $this->dates[] = $dateString;
@@ -212,6 +232,114 @@ final class OzonSellerReportConnectorTest extends TestCase
         self::assertSame('accrual-by-day:2026-06-01:2026-06-02', $result->rawBatch->externalId);
     }
 
+    public function testPullAccrualByDayCollectsAllPagesForDate(): void
+    {
+        $accrualClient = new class implements OzonAccrualClientInterface {
+            /**
+             * @var list<array{date: string, lastId: string|null}>
+             */
+            public array $calls = [];
+
+            public function fetchPostings(string $companyId, string $connectionRef, array $postingNumbers): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+
+            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date, ?string $lastId = null): OzonRawPage
+            {
+                $dateString = $date->format('Y-m-d');
+                $this->calls[] = ['date' => $dateString, 'lastId' => $lastId];
+
+                return match ($lastId) {
+                    null => new OzonRawPage(
+                        rows: [['date' => $dateString, 'accrual_id' => 'row-1']],
+                        hasMore: true,
+                        nextPageToken: 'cursor-1',
+                        metadata: ['page' => 1],
+                    ),
+                    'cursor-1' => new OzonRawPage(
+                        rows: [['date' => $dateString, 'accrual_id' => 'row-2']],
+                        hasMore: true,
+                        nextPageToken: 'cursor-2',
+                        metadata: ['page' => 2],
+                    ),
+                    'cursor-2' => new OzonRawPage(
+                        rows: [['date' => $dateString, 'accrual_id' => 'row-3']],
+                        hasMore: false,
+                        metadata: ['page' => 3],
+                    ),
+                    default => throw new \LogicException('Unexpected last_id.'),
+                };
+            }
+
+            public function fetchTypes(string $companyId, string $connectionRef): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+        };
+
+        $connector = $this->connector($accrualClient);
+        $result = $connector->pull(new PullRequest(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            cursorValue: null,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-01'),
+            syncJobId: Uuid::uuid7()->toString(),
+        ));
+
+        self::assertSame([
+            ['date' => '2026-06-01', 'lastId' => null],
+            ['date' => '2026-06-01', 'lastId' => 'cursor-1'],
+            ['date' => '2026-06-01', 'lastId' => 'cursor-2'],
+        ], $accrualClient->calls);
+        self::assertSame([
+            ['date' => '2026-06-01', 'accrual_id' => 'row-1'],
+            ['date' => '2026-06-01', 'accrual_id' => 'row-2'],
+            ['date' => '2026-06-01', 'accrual_id' => 'row-3'],
+        ], $result->rawBatch->rows);
+    }
+
+    public function testPullAccrualByDayRejectsRepeatedLastId(): void
+    {
+        $accrualClient = new class implements OzonAccrualClientInterface {
+            public function fetchPostings(string $companyId, string $connectionRef, array $postingNumbers): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+
+            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date, ?string $lastId = null): OzonRawPage
+            {
+                return new OzonRawPage(
+                    rows: [['date' => $date->format('Y-m-d'), 'accrual_id' => $lastId ?? 'first']],
+                    hasMore: true,
+                    nextPageToken: 'same-cursor',
+                );
+            }
+
+            public function fetchTypes(string $companyId, string $connectionRef): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+        };
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('repeated last_id');
+
+        $this->connector($accrualClient)->pull(new PullRequest(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            cursorValue: null,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-01'),
+            syncJobId: Uuid::uuid7()->toString(),
+        ));
+    }
+
     public function testIncrementalAccrualByDayContinuesWhileNextCursorIsOverdue(): void
     {
         $accrualClient = new class implements OzonAccrualClientInterface {
@@ -225,7 +353,7 @@ final class OzonSellerReportConnectorTest extends TestCase
                 throw new \LogicException('Not used.');
             }
 
-            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date): OzonRawPage
+            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date, ?string $lastId = null): OzonRawPage
             {
                 $this->dates[] = $date->format('Y-m-d');
 
@@ -268,7 +396,7 @@ final class OzonSellerReportConnectorTest extends TestCase
                 throw new \LogicException('Not used.');
             }
 
-            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date): OzonRawPage
+            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date, ?string $lastId = null): OzonRawPage
             {
                 $this->dates[] = $date->format('Y-m-d');
 
@@ -308,7 +436,7 @@ final class OzonSellerReportConnectorTest extends TestCase
                 throw new \LogicException('Not used.');
             }
 
-            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date): OzonRawPage
+            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date, ?string $lastId = null): OzonRawPage
             {
                 throw new \LogicException('Not used.');
             }
@@ -381,7 +509,7 @@ final class OzonSellerReportConnectorTest extends TestCase
                 throw new \LogicException('Not used.');
             }
 
-            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date): OzonRawPage
+            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date, ?string $lastId = null): OzonRawPage
             {
                 return new OzonRawPage(rows: $this->rows, hasMore: false);
             }
@@ -429,7 +557,7 @@ final class OzonSellerReportConnectorTest extends TestCase
                 throw new \LogicException('Not used.');
             }
 
-            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date): OzonRawPage
+            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date, ?string $lastId = null): OzonRawPage
             {
                 throw new \LogicException('Not used.');
             }

--- a/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
+++ b/site/tests/Unit/Ingestion/Application/Source/Ozon/OzonSellerReportConnectorTest.php
@@ -148,36 +148,6 @@ final class OzonSellerReportConnectorTest extends TestCase
                 '_ingestion_metadata' => [
                     'windowFrom' => '2026-06-01',
                     'windowTo' => '2026-06-02',
-                    'apiMetadata' => [
-                        [
-                            'date' => '2026-06-01',
-                            'metadata' => [
-                                'pageCount' => 1,
-                                'rowCount' => 0,
-                                'pages' => [[
-                                    'page' => 1,
-                                    'lastId' => null,
-                                    'nextLastId' => null,
-                                    'rowCount' => 0,
-                                    'metadata' => ['endpoint' => '/v1/finance/accrual/by-day'],
-                                ]],
-                            ],
-                        ],
-                        [
-                            'date' => '2026-06-02',
-                            'metadata' => [
-                                'pageCount' => 1,
-                                'rowCount' => 0,
-                                'pages' => [[
-                                    'page' => 1,
-                                    'lastId' => null,
-                                    'nextLastId' => null,
-                                    'rowCount' => 0,
-                                    'metadata' => ['endpoint' => '/v1/finance/accrual/by-day'],
-                                ]],
-                            ],
-                        ],
-                    ],
                 ],
             ],
         ], $result->rawBatch->rows);
@@ -300,6 +270,48 @@ final class OzonSellerReportConnectorTest extends TestCase
             ['date' => '2026-06-01', 'accrual_id' => 'row-2'],
             ['date' => '2026-06-01', 'accrual_id' => 'row-3'],
         ], $result->rawBatch->rows);
+    }
+
+    public function testPullAccrualByDayDoesNotStopAfterOneHundredPages(): void
+    {
+        $accrualClient = new class implements OzonAccrualClientInterface {
+            public int $calls = 0;
+
+            public function fetchPostings(string $companyId, string $connectionRef, array $postingNumbers): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+
+            public function fetchByDay(string $companyId, string $connectionRef, \DateTimeImmutable $date, ?string $lastId = null): OzonRawPage
+            {
+                ++$this->calls;
+
+                return new OzonRawPage(
+                    rows: [['date' => $date->format('Y-m-d'), 'accrual_id' => sprintf('row-%03d', $this->calls)]],
+                    hasMore: $this->calls < 101,
+                    nextPageToken: $this->calls < 101 ? sprintf('cursor-%03d', $this->calls) : null,
+                );
+            }
+
+            public function fetchTypes(string $companyId, string $connectionRef): OzonRawPage
+            {
+                throw new \LogicException('Not used.');
+            }
+        };
+
+        $result = $this->connector($accrualClient)->pull(new PullRequest(
+            companyId: Uuid::uuid7()->toString(),
+            connectionRef: 'connection-1',
+            shopRef: 'shop-1',
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            cursorValue: null,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-01'),
+            syncJobId: Uuid::uuid7()->toString(),
+        ));
+
+        self::assertSame(101, $accrualClient->calls);
+        self::assertCount(101, $result->rawBatch->rows);
     }
 
     public function testPullAccrualByDayRejectsRepeatedLastId(): void

--- a/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientTest.php
@@ -113,6 +113,31 @@ final class OzonAccrualClientTest extends TestCase
         self::assertSame('next-last-id', $page->nextPageToken);
     }
 
+    public function testFetchByDayIgnoresHasNextWhenLastIdIsEmpty(): void
+    {
+        $http = new MockHttpClient(static fn (): MockResponse => new MockResponse(
+            '{"result":{"accruals":[{"date":"2026-06-13","accrual_id":3}],"last_id":"","has_next":true}}',
+            ['http_code' => 200],
+        ));
+
+        $client = new OzonAccrualClient(
+            $http,
+            $this->credentialProvider(),
+            new NullLogger(),
+        );
+
+        $page = $client->fetchByDay(
+            '0192f0c2-0000-7000-8000-000000000001',
+            '0192f0c2-0000-7000-8000-000000000002',
+            new \DateTimeImmutable('2026-06-13'),
+            'previous-last-id',
+        );
+
+        self::assertSame([['date' => '2026-06-13', 'accrual_id' => 3]], $page->rows);
+        self::assertFalse($page->hasMore);
+        self::assertNull($page->nextPageToken);
+    }
+
     public function testFetchTypesSendsEmptyJsonObjectAndExtractsAccrualTypes(): void
     {
         $capturedUrl = null;

--- a/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientTest.php
+++ b/site/tests/Unit/Ingestion/Infrastructure/Api/Ozon/OzonAccrualClientTest.php
@@ -77,6 +77,40 @@ final class OzonAccrualClientTest extends TestCase
         self::assertSame('2026-06-13', $requestPayload['date']);
         self::assertSame([['date' => '2026-06-13', 'accrual_id' => 1]], $page->rows);
         self::assertFalse($page->hasMore);
+        self::assertNull($page->nextPageToken);
+    }
+
+    public function testFetchByDaySendsLastIdAndReturnsNextLastId(): void
+    {
+        $capturedOptions = null;
+        $http = new MockHttpClient(static function (string $method, string $url, array $options) use (&$capturedOptions): MockResponse {
+            $capturedOptions = $options;
+
+            return new MockResponse(
+                '{"result":{"accruals":[{"date":"2026-06-13","accrual_id":2}],"last_id":"next-last-id"}}',
+                ['http_code' => 200],
+            );
+        });
+
+        $client = new OzonAccrualClient(
+            $http,
+            $this->credentialProvider(),
+            new NullLogger(),
+        );
+
+        $page = $client->fetchByDay(
+            '0192f0c2-0000-7000-8000-000000000001',
+            '0192f0c2-0000-7000-8000-000000000002',
+            new \DateTimeImmutable('2026-06-13'),
+            'previous-last-id',
+        );
+
+        $requestPayload = $capturedOptions['json'] ?? json_decode((string) ($capturedOptions['body'] ?? ''), true, 512, \JSON_THROW_ON_ERROR);
+        self::assertSame('2026-06-13', $requestPayload['date']);
+        self::assertSame('previous-last-id', $requestPayload['last_id']);
+        self::assertSame([['date' => '2026-06-13', 'accrual_id' => 2]], $page->rows);
+        self::assertTrue($page->hasMore);
+        self::assertSame('next-last-id', $page->nextPageToken);
     }
 
     public function testFetchTypesSendsEmptyJsonObjectAndExtractsAccrualTypes(): void


### PR DESCRIPTION
## What changed
- Add `last_id` pagination support to the Ozon accrual by-day client.
- Make the Ozon seller report connector fetch every page for each accrual day instead of only the first page.
- Align by-day cursor handling with the existing Ozon inventory paginator: continuation is driven only by a non-empty `last_id`, without an artificial page cap.
- Keep the repeated-`last_id` guard to prevent deterministic cursor loops.

## Why
One Ozon cabinet had large daily accrual payloads. The previous ingestion path only loaded the first page per day, so canonical Ingestion financial transactions contained roughly half of the expected sale/income data after a month reload.

## Review scope note
This PR changes only Ingestion/Ozon pagination files and tests. The local deleted `docs/tasks/ingestion/*` files are not part of PR #2073; `gh pr diff 2073 --name-only` lists only the six Ingestion files.

## Validation
- Targeted Ozon accrual unit tests — OK, 22 tests.
- `make site-test-unit` — OK, 1232 tests; existing unrelated warning/deprecation remain in Storage/OpenSpout tests.
- Scoped `php-cs-fixer` dry-run for the six changed files — OK.

## Notes
Existing raw records saved from first-page-only responses must be reloaded after deploy so normalization can rebuild the missing transactions.