### PR TITLE
[codex] Add Ozon accrual rolling refresh

### DIFF
--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -87,6 +87,10 @@
 # Ежедневный инкрементальный запуск нового Ingestion pipeline.
 0 3 * * * cd /app && php bin/console app:ingestion:run-incremental --no-interaction --quiet
 
+# Ежедневный rolling refresh Ozon accrual by-day: пере-fetch последних 45 дней,
+# HTTP-загрузка выполняется async worker'ом, unchanged raw по hash не перенормализуется.
+30 2 * * * cd /app && php bin/console app:ingestion:ozon-accrual:rolling-refresh --days-back=45 --limit=50 --execute --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
+
 # Ежедневное обслуживание справочника категорий Ozon accrual:
 # seed code mappings → refresh metadata for all companies/shops → discover/rebuild taxonomy → health-check.
 15 5 * * * cd /app && php -d memory_limit=1G bin/console app:ingestion:ozon-accrual:daily-maintenance --days-back=45 --execute --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
@@ -96,6 +100,9 @@
 # после ingest_normalize workers дочищает товарное enrichment-связывание без повторного dispatch.
 45 5 * * * cd /app && php -d memory_limit=1G bin/console app:ingestion:ozon-accrual:reconcile-financial-projection --days-back=30 --execute --dispatch-normalization --summary-only --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
 30 6 * * * cd /app && php -d memory_limit=1G bin/console app:ingestion:ozon-accrual:reconcile-financial-projection --days-back=30 --execute --repair-enrichment-only --summary-only --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
+
+# Read-only контроль после rolling refresh и normalize workers: latest raw coverage vs canonical.
+45 6 * * * cd /app && php -d memory_limit=1G bin/console app:ingestion:ozon-accrual:verify-rolling-refresh --days-back=45 --limit=100 --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
 
 # Ежедневная загрузка Ozon Performance ingestion с начала месяца до вчерашнего дня.
 # Команда только планирует SyncJob/chunks; HTTP-загрузка выполняется async worker'ом.

--- a/site/src/Ingestion/Command/OzonAccrualRollingRefreshCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualRollingRefreshCommand.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\Command\StartBackfillCommand as StartBackfillApplicationCommand;
+use App\Ingestion\Application\DTO\ShopDescriptor;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Domain\Service\ConnectorRegistry;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Exception\ActiveBackfillExistsException;
+use App\Ingestion\Facade\SyncFacade;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Query\ActiveSellerConnectionsQuery;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:ozon-accrual:rolling-refresh',
+    description: 'Dispatches rolling Ozon accrual by-day backfills for active Ozon seller connections.',
+)]
+final class OzonAccrualRollingRefreshCommand extends Command
+{
+    use LockableTrait;
+
+    private const BUSINESS_TIMEZONE = 'Europe/Moscow';
+    private const MAX_DAYS_BACK = 365;
+    private const MAX_LIMIT = 500;
+    private const MAX_DISPATCH_SPACING_SECONDS = 3600;
+
+    public function __construct(
+        private readonly ClockInterface $clock,
+        private readonly ActiveSellerConnectionsQuery $connectionsQuery,
+        private readonly ConnectorRegistry $connectorRegistry,
+        private readonly SyncFacade $syncFacade,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('days-back', null, InputOption::VALUE_REQUIRED, 'Rolling refresh depth in days, 1..365.', 45)
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Optional company UUID filter.')
+            ->addOption('shop-ref', null, InputOption::VALUE_REQUIRED, 'Optional shop reference filter.')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum shop targets per run, 1..500.', 50)
+            ->addOption('dispatch-spacing-seconds', null, InputOption::VALUE_REQUIRED, 'Delay between shop backfill dispatches, 0..3600.', 0)
+            ->addOption('dry-run', null, InputOption::VALUE_NONE, 'Print planned refresh jobs without dispatching them.')
+            ->addOption('execute', null, InputOption::VALUE_NONE, 'Dispatch refresh jobs.');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if (!$this->lock()) {
+            $io->warning('Ozon accrual rolling refresh is already running.');
+
+            return Command::SUCCESS;
+        }
+
+        try {
+            return $this->runRefresh($input, $io);
+        } finally {
+            $this->release();
+        }
+    }
+
+    private function runRefresh(InputInterface $input, SymfonyStyle $io): int
+    {
+        try {
+            $dryRun = (bool) $input->getOption('dry-run');
+            $execute = (bool) $input->getOption('execute');
+            if ($dryRun === $execute) {
+                throw new \InvalidArgumentException('Choose exactly one action: --dry-run or --execute.');
+            }
+
+            $daysBack = $this->intOption($input, 'days-back', 1, self::MAX_DAYS_BACK);
+            $companyId = $this->companyId($input);
+            $shopRef = $this->stringOption($input, 'shop-ref');
+            $limit = $this->intOption($input, 'limit', 1, self::MAX_LIMIT);
+            $dispatchSpacingSeconds = $this->intOption($input, 'dispatch-spacing-seconds', 0, self::MAX_DISPATCH_SPACING_SECONDS);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        [$from, $to] = $this->window($daysBack);
+        $targets = array_slice($this->targets($companyId, $shopRef), 0, $limit);
+
+        $io->title('Ozon accrual rolling refresh');
+        $io->table(['setting', 'value'], [
+            ['mode', $dryRun ? 'dry-run' : 'execute'],
+            ['from', $from->format('Y-m-d')],
+            ['to', $to->format('Y-m-d')],
+            ['daysBack', (string) $daysBack],
+            ['companyId', $companyId ?? 'all'],
+            ['shopRef', $shopRef ?? 'all'],
+            ['limit', (string) $limit],
+            ['targets', (string) count($targets)],
+            ['dispatchSpacingSeconds', (string) $dispatchSpacingSeconds],
+        ]);
+
+        if ([] === $targets) {
+            $io->warning('No active Ozon seller shop targets found.');
+
+            return Command::SUCCESS;
+        }
+
+        $rows = [];
+        $started = 0;
+        $skippedActive = 0;
+        $failed = 0;
+
+        foreach ($targets as $index => $target) {
+            $initialDelaySeconds = $index * $dispatchSpacingSeconds;
+
+            if ($dryRun) {
+                $rows[] = [
+                    $target['companyId'],
+                    $target['connectionRef'],
+                    $target['shopRef'],
+                    $this->delayLabel($initialDelaySeconds),
+                    'dry-run',
+                ];
+                continue;
+            }
+
+            try {
+                $jobId = $this->syncFacade->startBackfill(new StartBackfillApplicationCommand(
+                    companyId: $target['companyId'],
+                    connectionRef: $target['connectionRef'],
+                    source: IngestSource::OZON,
+                    resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+                    shopRef: $target['shopRef'],
+                    windowFrom: $from,
+                    windowTo: $to,
+                    initialDelaySeconds: $initialDelaySeconds,
+                ));
+
+                ++$started;
+                $rows[] = [$target['companyId'], $target['connectionRef'], $target['shopRef'], $this->delayLabel($initialDelaySeconds), $jobId];
+            } catch (ActiveBackfillExistsException) {
+                ++$skippedActive;
+                $rows[] = [$target['companyId'], $target['connectionRef'], $target['shopRef'], $this->delayLabel($initialDelaySeconds), 'active'];
+            } catch (\Throwable $exception) {
+                ++$failed;
+                $rows[] = [$target['companyId'], $target['connectionRef'], $target['shopRef'], $this->delayLabel($initialDelaySeconds), 'failed'];
+                $this->logger->warning('Failed to dispatch Ozon accrual rolling refresh job.', [
+                    'companyId' => $target['companyId'],
+                    'connectionRef' => $target['connectionRef'],
+                    'shopRef' => $target['shopRef'],
+                    'exceptionClass' => $exception::class,
+                    'errorMessage' => $exception->getMessage(),
+                ]);
+            }
+        }
+
+        $io->section('Dispatch result');
+        $io->table(['companyId', 'connectionRef', 'shopRef', 'delay', 'status'], $rows);
+        $io->table(['metric', 'value'], [
+            ['targets', (string) count($targets)],
+            ['started', (string) $started],
+            ['skippedActive', (string) $skippedActive],
+            ['failed', (string) $failed],
+        ]);
+
+        $this->logger->info('Ozon accrual rolling refresh finished.', [
+            'mode' => $dryRun ? 'dry-run' : 'execute',
+            'from' => $from->format('Y-m-d'),
+            'to' => $to->format('Y-m-d'),
+            'daysBack' => $daysBack,
+            'companyId' => $companyId,
+            'shopRef' => $shopRef,
+            'targets' => count($targets),
+            'started' => $started,
+            'skippedActive' => $skippedActive,
+            'failed' => $failed,
+        ]);
+
+        if ($dryRun) {
+            $io->note('Dry-run only. No jobs were dispatched.');
+
+            return Command::SUCCESS;
+        }
+
+        return 0 === $started && $failed > 0 ? Command::FAILURE : Command::SUCCESS;
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function window(int $daysBack): array
+    {
+        $today = \DateTimeImmutable::createFromInterface(
+            $this->clock->now()->setTimezone(new \DateTimeZone(self::BUSINESS_TIMEZONE)),
+        )->setTime(0, 0);
+
+        return [$today->modify(sprintf('-%d days', $daysBack)), $today->modify('-1 day')];
+    }
+
+    /**
+     * @return list<array{companyId: string, connectionRef: string, shopRef: string}>
+     */
+    private function targets(?string $companyId, ?string $shopRef): array
+    {
+        $targets = [];
+        $connector = $this->connectorRegistry->get(IngestSource::OZON, OzonResourceType::ACCRUAL_BY_DAY);
+
+        foreach ($this->connectionsQuery->execute() as $connection) {
+            if (MarketplaceType::OZON->value !== (string) $connection['marketplace']) {
+                continue;
+            }
+
+            $connectionCompanyId = (string) $connection['company_id'];
+            if (null !== $companyId && $connectionCompanyId !== $companyId) {
+                continue;
+            }
+
+            $connectionRef = (string) $connection['id'];
+
+            try {
+                $shops = $connector->discoverShops($connectionCompanyId, $connectionRef);
+            } catch (\Throwable $exception) {
+                $this->logger->warning('Failed to discover Ozon accrual rolling refresh shops.', [
+                    'companyId' => $connectionCompanyId,
+                    'connectionRef' => $connectionRef,
+                    'exceptionClass' => $exception::class,
+                    'errorMessage' => $exception->getMessage(),
+                ]);
+                continue;
+            }
+
+            foreach ($shops as $shop) {
+                if (!$shop instanceof ShopDescriptor) {
+                    continue;
+                }
+
+                if (null !== $shopRef && $shop->externalId !== $shopRef) {
+                    continue;
+                }
+
+                $targets[] = [
+                    'companyId' => $connectionCompanyId,
+                    'connectionRef' => $connectionRef,
+                    'shopRef' => $shop->externalId,
+                ];
+            }
+        }
+
+        return $targets;
+    }
+
+    private function companyId(InputInterface $input): ?string
+    {
+        $companyId = $this->stringOption($input, 'company-id');
+        if (null === $companyId) {
+            return null;
+        }
+
+        Assert::uuid($companyId, 'Invalid --company-id UUID.');
+
+        return $companyId;
+    }
+
+    private function stringOption(InputInterface $input, string $name): ?string
+    {
+        $value = trim((string) $input->getOption($name));
+
+        return '' === $value ? null : $value;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $value = (string) $input->getOption($name);
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        $intValue = (int) $value;
+        if ($intValue < $min || $intValue > $max) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        return $intValue;
+    }
+
+    private function delayLabel(int $initialDelaySeconds): string
+    {
+        return 0 === $initialDelaySeconds ? 'none' : sprintf('%ds', $initialDelaySeconds);
+    }
+}

--- a/site/src/Ingestion/Command/OzonAccrualVerifyRollingRefreshCommand.php
+++ b/site/src/Ingestion/Command/OzonAccrualVerifyRollingRefreshCommand.php
@@ -1,0 +1,512 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Ingestion\Command;
+
+use App\Ingestion\Application\DTO\ShopDescriptor;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualByDayPreviewMapper;
+use App\Ingestion\Application\Source\Ozon\OzonAccrualPreviewTransaction;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Domain\Service\ConnectorRegistry;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\RawNormalizationStatus;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Infrastructure\Query\OzonAccrualRawRecordQuery;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Marketplace\Infrastructure\Query\ActiveSellerConnectionsQuery;
+use Doctrine\DBAL\Connection;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Clock\ClockInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Command\LockableTrait;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Style\SymfonyStyle;
+use Webmozart\Assert\Assert;
+
+#[AsCommand(
+    name: 'app:ingestion:ozon-accrual:verify-rolling-refresh',
+    description: 'Checks latest Ozon accrual by-day raw coverage against normalized financial transactions.',
+)]
+final class OzonAccrualVerifyRollingRefreshCommand extends Command
+{
+    use LockableTrait;
+
+    private const BUSINESS_TIMEZONE = 'Europe/Moscow';
+    private const MAX_DAYS_BACK = 365;
+    private const MAX_TARGET_LIMIT = 500;
+
+    public function __construct(
+        private readonly ClockInterface $clock,
+        private readonly ActiveSellerConnectionsQuery $connectionsQuery,
+        private readonly ConnectorRegistry $connectorRegistry,
+        private readonly RawStorageFacade $rawStorageFacade,
+        private readonly OzonAccrualByDayPreviewMapper $previewMapper,
+        private readonly OzonAccrualRawRecordQuery $rawRecordQuery,
+        private readonly Connection $connection,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('days-back', null, InputOption::VALUE_REQUIRED, 'Rolling verification depth in days, 1..365.', 45)
+            ->addOption('company-id', null, InputOption::VALUE_REQUIRED, 'Optional company UUID filter.')
+            ->addOption('shop-ref', null, InputOption::VALUE_REQUIRED, 'Optional shop reference filter.')
+            ->addOption('limit', null, InputOption::VALUE_REQUIRED, 'Maximum shop targets per run, 1..500.', 100)
+            ->addOption('raw-limit', null, InputOption::VALUE_REQUIRED, 'Latest raw records to scan per shop, 1..500.', 100)
+            ->addOption('raw-row-limit', null, InputOption::VALUE_REQUIRED, 'Rows to scan per raw record, 1..100000.', 50000);
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $io = new SymfonyStyle($input, $output);
+
+        if (!$this->lock()) {
+            $io->warning('Ozon accrual rolling refresh verification is already running.');
+
+            return Command::SUCCESS;
+        }
+
+        try {
+            return $this->runVerification($input, $io);
+        } finally {
+            $this->release();
+        }
+    }
+
+    private function runVerification(InputInterface $input, SymfonyStyle $io): int
+    {
+        try {
+            $daysBack = $this->intOption($input, 'days-back', 1, self::MAX_DAYS_BACK);
+            $companyId = $this->companyId($input);
+            $shopRef = $this->stringOption($input, 'shop-ref');
+            $limit = $this->intOption($input, 'limit', 1, self::MAX_TARGET_LIMIT);
+            $rawLimit = $this->intOption($input, 'raw-limit', 1, 500);
+            $rawRowLimit = $this->intOption($input, 'raw-row-limit', 1, 100000);
+        } catch (\Throwable $exception) {
+            $io->error($exception->getMessage());
+
+            return Command::FAILURE;
+        }
+
+        [$from, $to] = $this->window($daysBack);
+        $targets = array_slice($this->targets($companyId, $shopRef), 0, $limit);
+
+        $io->title('Ozon accrual rolling refresh verification');
+        $io->table(['setting', 'value'], [
+            ['from', $from->format('Y-m-d')],
+            ['to', $to->format('Y-m-d')],
+            ['daysBack', (string) $daysBack],
+            ['companyId', $companyId ?? 'all'],
+            ['shopRef', $shopRef ?? 'all'],
+            ['limit', (string) $limit],
+            ['rawLimit', (string) $rawLimit],
+            ['rawRowLimit', (string) $rawRowLimit],
+            ['targets', (string) count($targets)],
+        ]);
+
+        if ([] === $targets) {
+            $io->warning('No active Ozon seller shop targets found.');
+
+            return Command::SUCCESS;
+        }
+
+        $rows = [];
+        $failedTargets = 0;
+        $totals = [
+            'targets' => count($targets),
+            'rawRecords' => 0,
+            'previewRows' => 0,
+            'nonDoneRaw' => 0,
+            'unknownCategoryRows' => 0,
+            'amountMismatches' => 0,
+            'countMismatches' => 0,
+        ];
+
+        foreach ($targets as $target) {
+            $result = $this->verifyTarget($target, $from, $to, $rawLimit, $rawRowLimit);
+
+            foreach ($totals as $metric => $value) {
+                if ('targets' === $metric) {
+                    continue;
+                }
+
+                $totals[$metric] += $result[$metric];
+            }
+
+            if (!$result['ok']) {
+                ++$failedTargets;
+            }
+
+            $rows[] = [
+                $target['companyId'],
+                $target['shopRef'],
+                $result['ok'] ? 'ok' : 'fail',
+                (string) $result['rawRecords'],
+                (string) $result['previewRows'],
+                (string) $result['nonDoneRaw'],
+                (string) $result['unknownCategoryRows'],
+                (string) $result['amountMismatches'],
+                (string) $result['countMismatches'],
+            ];
+        }
+
+        $io->section('Verification result');
+        $io->table(
+            ['companyId', 'shopRef', 'status', 'rawRecords', 'previewRows', 'nonDoneRaw', 'unknownCategories', 'amountMismatches', 'countMismatches'],
+            $rows,
+        );
+        $summaryRows = [];
+        foreach ($totals + ['failedTargets' => $failedTargets] as $metric => $value) {
+            $summaryRows[] = [$metric, (string) $value];
+        }
+
+        $io->table(['metric', 'value'], $summaryRows);
+
+        $this->logger->info('Ozon accrual rolling refresh verification finished.', $totals + [
+            'failedTargets' => $failedTargets,
+            'from' => $from->format('Y-m-d'),
+            'to' => $to->format('Y-m-d'),
+            'companyId' => $companyId,
+            'shopRef' => $shopRef,
+        ]);
+
+        if ($failedTargets > 0) {
+            $this->logger->warning('Ozon accrual rolling refresh verification found mismatches.', [
+                'failedTargets' => $failedTargets,
+                'from' => $from->format('Y-m-d'),
+                'to' => $to->format('Y-m-d'),
+            ]);
+
+            return Command::FAILURE;
+        }
+
+        return Command::SUCCESS;
+    }
+
+    /**
+     * @param array{companyId: string, connectionRef: string, shopRef: string} $target
+     *
+     * @return array{ok: bool, rawRecords: int, previewRows: int, nonDoneRaw: int, unknownCategoryRows: int, amountMismatches: int, countMismatches: int}
+     */
+    private function verifyTarget(array $target, \DateTimeImmutable $from, \DateTimeImmutable $to, int $rawLimit, int $rawRowLimit): array
+    {
+        $rawRecords = $this->rawRecordQuery->latestCoverageRows($target['companyId'], $target['shopRef'], $from, $to, $rawLimit);
+        $doneRawRecords = array_values(array_filter(
+            $rawRecords,
+            static fn (array $row): bool => RawNormalizationStatus::DONE->value === (string) $row['normalization_status'],
+        ));
+        $nonDoneRaw = count($rawRecords) - count($doneRawRecords);
+
+        $previewRows = $this->previewMapper->preview(
+            $target['companyId'],
+            $this->rawRows($target['companyId'], $doneRawRecords, $rawRowLimit, $from, $to),
+            $from,
+            $to,
+            includeSaleRefund: true,
+        );
+
+        $parityRows = $this->parityRows($previewRows, $this->canonicalGroups($target['companyId'], $target['shopRef'], $from, $to));
+        $unknownCategoryRows = 0;
+        foreach ($previewRows as $row) {
+            if (false === $row->ozonCategoryKnown) {
+                ++$unknownCategoryRows;
+            }
+        }
+
+        $amountMismatches = 0;
+        $countMismatches = 0;
+        foreach ($parityRows as $row) {
+            if (0 !== $row['totalDeltaMinor']) {
+                ++$amountMismatches;
+            }
+
+            if (0 !== $row['countDelta']) {
+                ++$countMismatches;
+            }
+        }
+
+        $ok = [] !== $rawRecords
+            && 0 === $nonDoneRaw
+            && 0 === $unknownCategoryRows
+            && 0 === $amountMismatches
+            && 0 === $countMismatches;
+
+        return [
+            'ok' => $ok,
+            'rawRecords' => count($rawRecords),
+            'previewRows' => count($previewRows),
+            'nonDoneRaw' => $nonDoneRaw,
+            'unknownCategoryRows' => $unknownCategoryRows,
+            'amountMismatches' => $amountMismatches,
+            'countMismatches' => $countMismatches,
+        ];
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rawRecords
+     *
+     * @return \Generator<int, array<string, mixed>>
+     */
+    private function rawRows(
+        string $companyId,
+        array $rawRecords,
+        int $rowLimit,
+        \DateTimeImmutable $from,
+        \DateTimeImmutable $to,
+    ): \Generator {
+        foreach ($rawRecords as $rawRecord) {
+            $recordRows = 0;
+            $selectedDates = $this->selectedDateSet($rawRecord);
+            foreach ($this->rawStorageFacade->read((string) $rawRecord['id'], $companyId) as $row) {
+                if ($recordRows >= $rowLimit) {
+                    break;
+                }
+
+                ++$recordRows;
+                if (!$this->rowDateInWindow($row, $from, $to, $selectedDates)) {
+                    continue;
+                }
+
+                yield $row;
+            }
+        }
+    }
+
+    /**
+     * @param array<string, mixed> $row
+     * @param array<string, true> $selectedDates
+     */
+    private function rowDateInWindow(array $row, \DateTimeImmutable $from, \DateTimeImmutable $to, array $selectedDates): bool
+    {
+        $date = trim((string) ($row['date'] ?? ''));
+        if (!preg_match('/^\d{4}-\d{2}-\d{2}$/', $date)) {
+            return false;
+        }
+
+        if ([] !== $selectedDates) {
+            return isset($selectedDates[$date]);
+        }
+
+        return $date >= $from->format('Y-m-d') && $date <= $to->format('Y-m-d');
+    }
+
+    /**
+     * @param array<string, mixed> $rawRecord
+     *
+     * @return array<string, true>
+     */
+    private function selectedDateSet(array $rawRecord): array
+    {
+        $dates = $rawRecord['selected_dates'] ?? [];
+        if (!is_array($dates)) {
+            return [];
+        }
+
+        $set = [];
+        foreach ($dates as $date) {
+            $set[(string) $date] = true;
+        }
+
+        return $set;
+    }
+
+    /**
+     * @return array<string, array{count: int, totalMinor: int}>
+     */
+    private function canonicalGroups(string $companyId, string $shopRef, \DateTimeImmutable $from, \DateTimeImmutable $to): array
+    {
+        $rows = $this->connection->fetchAllAssociative(
+            'SELECT DATE(occurred_at) AS date,
+                    type,
+                    direction,
+                    COUNT(*) AS count,
+                    COALESCE(SUM(amount_minor), 0) AS total_minor
+             FROM ingest_financial_transactions
+             WHERE company_id = :companyId
+               AND source = :source
+               AND shop_ref = :shopRef
+               AND occurred_at >= :fromAt
+               AND occurred_at < :toExclusive
+             GROUP BY DATE(occurred_at), type, direction',
+            [
+                'companyId' => $companyId,
+                'source' => IngestSource::OZON->value,
+                'shopRef' => $shopRef,
+                'fromAt' => $from->format('Y-m-d 00:00:00'),
+                'toExclusive' => $to->modify('+1 day')->format('Y-m-d 00:00:00'),
+            ],
+        );
+
+        $groups = [];
+        foreach ($rows as $row) {
+            $groups[$this->groupKey((string) $row['date'], (string) $row['type'], (string) $row['direction'])] = [
+                'count' => (int) $row['count'],
+                'totalMinor' => (int) $row['total_minor'],
+            ];
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $previewRows
+     * @param array<string, array{count: int, totalMinor: int}> $canonicalGroups
+     *
+     * @return list<array{countDelta: int, totalDeltaMinor: int}>
+     */
+    private function parityRows(array $previewRows, array $canonicalGroups): array
+    {
+        $previewGroups = $this->previewGroups($previewRows);
+        $keys = array_values(array_unique(array_merge(array_keys($previewGroups), array_keys($canonicalGroups))));
+        sort($keys);
+
+        $rows = [];
+        foreach ($keys as $key) {
+            $previewCount = (int) ($previewGroups[$key]['count'] ?? 0);
+            $previewTotal = (int) ($previewGroups[$key]['totalMinor'] ?? 0);
+            $canonicalCount = (int) ($canonicalGroups[$key]['count'] ?? 0);
+            $canonicalTotal = (int) ($canonicalGroups[$key]['totalMinor'] ?? 0);
+
+            $rows[] = [
+                'countDelta' => $previewCount - $canonicalCount,
+                'totalDeltaMinor' => $previewTotal - $canonicalTotal,
+            ];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * @param list<OzonAccrualPreviewTransaction> $previewRows
+     *
+     * @return array<string, array{count: int, totalMinor: int}>
+     */
+    private function previewGroups(array $previewRows): array
+    {
+        $groups = [];
+        foreach ($previewRows as $row) {
+            $key = $this->groupKey($row->date, $row->type->value, $row->direction->value);
+            if (!isset($groups[$key])) {
+                $groups[$key] = [
+                    'count' => 0,
+                    'totalMinor' => 0,
+                ];
+            }
+
+            ++$groups[$key]['count'];
+            $groups[$key]['totalMinor'] += $row->amountMinor;
+        }
+
+        return $groups;
+    }
+
+    /**
+     * @return array{0: \DateTimeImmutable, 1: \DateTimeImmutable}
+     */
+    private function window(int $daysBack): array
+    {
+        $today = \DateTimeImmutable::createFromInterface(
+            $this->clock->now()->setTimezone(new \DateTimeZone(self::BUSINESS_TIMEZONE)),
+        )->setTime(0, 0);
+
+        return [$today->modify(sprintf('-%d days', $daysBack)), $today->modify('-1 day')];
+    }
+
+    /**
+     * @return list<array{companyId: string, connectionRef: string, shopRef: string}>
+     */
+    private function targets(?string $companyId, ?string $shopRef): array
+    {
+        $targets = [];
+        $connector = $this->connectorRegistry->get(IngestSource::OZON, OzonResourceType::ACCRUAL_BY_DAY);
+
+        foreach ($this->connectionsQuery->execute() as $connection) {
+            if (MarketplaceType::OZON->value !== (string) $connection['marketplace']) {
+                continue;
+            }
+
+            $connectionCompanyId = (string) $connection['company_id'];
+            if (null !== $companyId && $connectionCompanyId !== $companyId) {
+                continue;
+            }
+
+            $connectionRef = (string) $connection['id'];
+
+            try {
+                $shops = $connector->discoverShops($connectionCompanyId, $connectionRef);
+            } catch (\Throwable $exception) {
+                $this->logger->warning('Failed to discover Ozon accrual verification shops.', [
+                    'companyId' => $connectionCompanyId,
+                    'connectionRef' => $connectionRef,
+                    'exceptionClass' => $exception::class,
+                    'errorMessage' => $exception->getMessage(),
+                ]);
+                continue;
+            }
+
+            foreach ($shops as $shop) {
+                if (!$shop instanceof ShopDescriptor) {
+                    continue;
+                }
+
+                if (null !== $shopRef && $shop->externalId !== $shopRef) {
+                    continue;
+                }
+
+                $targets[] = [
+                    'companyId' => $connectionCompanyId,
+                    'connectionRef' => $connectionRef,
+                    'shopRef' => $shop->externalId,
+                ];
+            }
+        }
+
+        return $targets;
+    }
+
+    private function groupKey(string $date, string $type, string $direction): string
+    {
+        return implode('|', [$date, $type, $direction]);
+    }
+
+    private function companyId(InputInterface $input): ?string
+    {
+        $companyId = $this->stringOption($input, 'company-id');
+        if (null === $companyId) {
+            return null;
+        }
+
+        Assert::uuid($companyId, 'Invalid --company-id UUID.');
+
+        return $companyId;
+    }
+
+    private function stringOption(InputInterface $input, string $name): ?string
+    {
+        $value = trim((string) $input->getOption($name));
+
+        return '' === $value ? null : $value;
+    }
+
+    private function intOption(InputInterface $input, string $name, int $min, int $max): int
+    {
+        $value = (string) $input->getOption($name);
+        if (!ctype_digit($value)) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        $intValue = (int) $value;
+        if ($intValue < $min || $intValue > $max) {
+            throw new \InvalidArgumentException(sprintf('The --%s option must be an integer from %d to %d.', $name, $min, $max));
+        }
+
+        return $intValue;
+    }
+}

--- a/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
+++ b/site/src/Ingestion/MessageHandler/RunSyncChunkHandler.php
@@ -11,6 +11,7 @@ use App\Ingestion\Application\Command\UpdateCursorCommand;
 use App\Ingestion\Application\DTO\PullRequest;
 use App\Ingestion\Application\Service\IngestRateLimitGuard;
 use App\Ingestion\Domain\Service\ConnectorRegistry;
+use App\Ingestion\Enum\RawNormalizationStatus;
 use App\Ingestion\Entity\SyncJob;
 use App\Ingestion\Exception\ConnectorAuthException;
 use App\Ingestion\Exception\ConnectorRateLimitedException;
@@ -99,6 +100,10 @@ final readonly class RunSyncChunkHandler
                     $records = $this->rawStorageFacade->store($result->rawBatch);
                     if ($result->normalizeRawRecords) {
                         foreach ($records as $record) {
+                            if (RawNormalizationStatus::DONE === $record->getNormalizationStatus()) {
+                                continue;
+                            }
+
                             $this->messageBus->dispatch(new NormalizeRawRecordMessage($record->getId(), $record->getCompanyId()));
                         }
                     } else {

--- a/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonIngestionFlowTest.php
+++ b/site/tests/Integration/Ingestion/Application/Source/Ozon/OzonIngestionFlowTest.php
@@ -91,6 +91,59 @@ final class OzonIngestionFlowTest extends IntegrationTestCase
         self::assertSame([], $issueRepository->findOpenByRawRecord($companyId, $normalizeMessage->rawRecordId));
     }
 
+    public function testRunSyncChunkDoesNotDispatchNormalizationForUnchangedDoneRaw(): void
+    {
+        $companyId = Uuid::uuid7()->toString();
+
+        $firstJob = new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'marketplace:ozon:seller',
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-18'),
+            windowTo: new \DateTimeImmutable('2026-06-18'),
+            shopRef: 'ozon-shop',
+        );
+        $this->em->persist($firstJob);
+        $this->em->flush();
+
+        $normalizeTransport = $this->getNormalizeTransport();
+        $normalizeTransport->reset();
+
+        /** @var RunSyncChunkHandler $syncHandler */
+        $syncHandler = self::getContainer()->get(RunSyncChunkHandler::class);
+        $syncHandler(new RunSyncChunkMessage($companyId, $firstJob->getId()));
+
+        $envelopes = $normalizeTransport->getSent();
+        self::assertCount(1, $envelopes);
+
+        /** @var NormalizeRawRecordMessage $normalizeMessage */
+        $normalizeMessage = $envelopes[0]->getMessage();
+        /** @var NormalizeRawRecordHandler $normalizeHandler */
+        $normalizeHandler = self::getContainer()->get(NormalizeRawRecordHandler::class);
+        $normalizeHandler($normalizeMessage);
+        $this->em->clear();
+
+        $secondJob = new SyncJob(
+            companyId: $companyId,
+            connectionRef: 'marketplace:ozon:seller',
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-18'),
+            windowTo: new \DateTimeImmutable('2026-06-18'),
+            shopRef: 'ozon-shop',
+        );
+        $this->em->persist($secondJob);
+        $this->em->flush();
+
+        $normalizeTransport->reset();
+        $syncHandler(new RunSyncChunkMessage($companyId, $secondJob->getId()));
+
+        self::assertCount(0, $normalizeTransport->getSent());
+    }
+
     public function testPreviewMapperUsesStoredAccrualTypesDictionary(): void
     {
         $companyId = Uuid::uuid7()->toString();

--- a/site/tests/Integration/Ingestion/Command/OzonAccrualRollingRefreshCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonAccrualRollingRefreshCommandTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Command;
+
+use App\Company\Entity\Company;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\Entity\SyncJob;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Enum\SyncJobKind;
+use App\Ingestion\Message\RunSyncChunkMessage;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Messenger\Transport\InMemory\InMemoryTransport;
+
+final class OzonAccrualRollingRefreshCommandTest extends IntegrationTestCase
+{
+    public function testDryRunDoesNotCreateJobsOrDispatchMessages(): void
+    {
+        $company = $this->seedCompany(2101);
+        $this->seedConnection($company, '77777777-7777-7777-7777-000000002101');
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:ozon-accrual:rolling-refresh');
+        $exit = $tester->execute([
+            '--company-id' => $company->getId(),
+            '--days-back' => '14',
+            '--dry-run' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('dry-run', $tester->getDisplay());
+        self::assertSame(0, $this->backfillJobCount($company->getId()));
+        self::assertCount(0, $transport->getSent());
+    }
+
+    public function testExecuteStartsAccrualBackfillOnlyForOzonSellerConnections(): void
+    {
+        $ozonCompany = $this->seedCompany(2102);
+        $ozonConnection = $this->seedConnection($ozonCompany, '77777777-7777-7777-7777-000000002102');
+
+        $wbCompany = $this->seedCompany(2103);
+        $this->seedConnection($wbCompany, '77777777-7777-7777-7777-000000002103', MarketplaceType::WILDBERRIES);
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:ozon-accrual:rolling-refresh');
+        $exit = $tester->execute([
+            '--days-back' => '14',
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertSame(1, $this->parentBackfillJobCount($ozonCompany->getId()));
+        self::assertSame(0, $this->parentBackfillJobCount($wbCompany->getId()));
+
+        $parent = $this->connection->fetchAssociative(
+            'SELECT resource_type, shop_ref, progress_total
+             FROM ingest_sync_jobs
+             WHERE company_id = :companyId AND parent_job_id IS NULL',
+            ['companyId' => $ozonCompany->getId()],
+        );
+
+        self::assertIsArray($parent);
+        self::assertSame(OzonResourceType::ACCRUAL_BY_DAY, $parent['resource_type']);
+        self::assertSame($ozonConnection->getId(), $parent['shop_ref']);
+        self::assertSame(2, (int) $parent['progress_total']);
+
+        $envelopes = $transport->getSent();
+        self::assertCount(2, $envelopes);
+        foreach ($envelopes as $envelope) {
+            self::assertInstanceOf(RunSyncChunkMessage::class, $envelope->getMessage());
+        }
+    }
+
+    public function testActiveBackfillIsSkipped(): void
+    {
+        $company = $this->seedCompany(2104);
+        $connection = $this->seedConnection($company, '77777777-7777-7777-7777-000000002104');
+
+        $activeJob = new SyncJob(
+            companyId: $company->getId(),
+            connectionRef: $connection->getId(),
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            kind: SyncJobKind::BACKFILL,
+            windowFrom: new \DateTimeImmutable('2026-06-01'),
+            windowTo: new \DateTimeImmutable('2026-06-07'),
+            shopRef: $connection->getId(),
+        );
+        $this->em->persist($activeJob);
+        $this->em->flush();
+
+        $transport = $this->getIngestFetchTransport();
+        $transport->reset();
+
+        $tester = $this->tester('app:ingestion:ozon-accrual:rolling-refresh');
+        $exit = $tester->execute([
+            '--company-id' => $company->getId(),
+            '--days-back' => '14',
+            '--execute' => true,
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('active', $tester->getDisplay());
+        self::assertSame(1, $this->parentBackfillJobCount($company->getId()));
+        self::assertCount(0, $transport->getSent());
+    }
+
+    private function seedCompany(int $index): Company
+    {
+        $owner = UserBuilder::aUser()->withIndex($index)->build();
+        $company = CompanyBuilder::aCompany()->withIndex($index)->withOwner($owner)->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+        $this->em->flush();
+
+        return $company;
+    }
+
+    private function seedConnection(
+        Company $company,
+        string $id,
+        MarketplaceType $marketplace = MarketplaceType::OZON,
+    ): MarketplaceConnection {
+        $connection = new MarketplaceConnection(
+            id: $id,
+            company: $company,
+            marketplace: $marketplace,
+            connectionType: MarketplaceConnectionType::SELLER,
+        );
+        $connection->setApiKey('test-key');
+        $connection->setClientId('test-client-id');
+        $connection->setIsActive(true);
+
+        $this->em->persist($connection);
+        $this->em->flush();
+
+        return $connection;
+    }
+
+    private function backfillJobCount(string $companyId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*) FROM ingest_sync_jobs WHERE company_id = :companyId AND kind = :kind',
+            ['companyId' => $companyId, 'kind' => SyncJobKind::BACKFILL->value],
+        );
+    }
+
+    private function parentBackfillJobCount(string $companyId): int
+    {
+        return (int) $this->connection->fetchOne(
+            'SELECT COUNT(*)
+             FROM ingest_sync_jobs
+             WHERE company_id = :companyId AND kind = :kind AND parent_job_id IS NULL',
+            ['companyId' => $companyId, 'kind' => SyncJobKind::BACKFILL->value],
+        );
+    }
+
+    private function tester(string $commandName): CommandTester
+    {
+        $app = new Application(self::$kernel);
+
+        return new CommandTester($app->find($commandName));
+    }
+
+    private function getIngestFetchTransport(): InMemoryTransport
+    {
+        /** @var InMemoryTransport $transport */
+        $transport = self::getContainer()->get('messenger.transport.ingest_fetch');
+
+        return $transport;
+    }
+}

--- a/site/tests/Integration/Ingestion/Command/OzonAccrualVerifyRollingRefreshCommandTest.php
+++ b/site/tests/Integration/Ingestion/Command/OzonAccrualVerifyRollingRefreshCommandTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Ingestion\Command;
+
+use App\Company\Entity\Company;
+use App\Ingestion\Application\Source\Ozon\OzonResourceType;
+use App\Ingestion\DTO\RawBatch;
+use App\Ingestion\Entity\IngestRawRecord;
+use App\Ingestion\Enum\IngestSource;
+use App\Ingestion\Facade\RawStorageFacade;
+use App\Ingestion\Message\NormalizeRawRecordMessage;
+use App\Ingestion\MessageHandler\NormalizeRawRecordHandler;
+use App\Marketplace\Entity\MarketplaceConnection;
+use App\Marketplace\Enum\MarketplaceConnectionType;
+use App\Marketplace\Enum\MarketplaceType;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class OzonAccrualVerifyRollingRefreshCommandTest extends IntegrationTestCase
+{
+    public function testPassesWhenLatestRawMatchesCanonicalTransactions(): void
+    {
+        $company = $this->seedCompany(2201);
+        $connection = $this->seedConnection($company, '77777777-7777-7777-7777-000000002201');
+        $date = (new \DateTimeImmutable('yesterday'))->format('Y-m-d');
+
+        $rawRecord = $this->storeAccrualRaw($company->getId(), $connection->getId(), $date, 220100);
+
+        /** @var NormalizeRawRecordHandler $handler */
+        $handler = self::getContainer()->get(NormalizeRawRecordHandler::class);
+        $handler(new NormalizeRawRecordMessage($rawRecord->getId(), $company->getId()));
+        $this->em->clear();
+
+        $tester = $this->tester('app:ingestion:ozon-accrual:verify-rolling-refresh');
+        $exit = $tester->execute([
+            '--company-id' => $company->getId(),
+            '--days-back' => '2',
+        ]);
+
+        self::assertSame(Command::SUCCESS, $exit);
+        self::assertStringContainsString('ok', $tester->getDisplay());
+        self::assertStringContainsString('amountMismatches', $tester->getDisplay());
+    }
+
+    public function testFailsWhenDoneRawHasNoCanonicalTransactions(): void
+    {
+        $company = $this->seedCompany(2202);
+        $connection = $this->seedConnection($company, '77777777-7777-7777-7777-000000002202');
+        $date = (new \DateTimeImmutable('yesterday'))->format('Y-m-d');
+
+        $rawRecord = $this->storeAccrualRaw($company->getId(), $connection->getId(), $date, 220200);
+        $rawRecord->markNormalizationDone();
+        $this->em->flush();
+
+        $tester = $this->tester('app:ingestion:ozon-accrual:verify-rolling-refresh');
+        $exit = $tester->execute([
+            '--company-id' => $company->getId(),
+            '--days-back' => '2',
+        ]);
+
+        self::assertSame(Command::FAILURE, $exit);
+        self::assertStringContainsString('fail', $tester->getDisplay());
+    }
+
+    private function seedCompany(int $index): Company
+    {
+        $owner = UserBuilder::aUser()->withIndex($index)->build();
+        $company = CompanyBuilder::aCompany()->withIndex($index)->withOwner($owner)->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+        $this->em->flush();
+
+        return $company;
+    }
+
+    private function seedConnection(Company $company, string $id): MarketplaceConnection
+    {
+        $connection = new MarketplaceConnection(
+            id: $id,
+            company: $company,
+            marketplace: MarketplaceType::OZON,
+            connectionType: MarketplaceConnectionType::SELLER,
+        );
+        $connection->setApiKey('test-key');
+        $connection->setClientId('test-client-id');
+        $connection->setIsActive(true);
+
+        $this->em->persist($connection);
+        $this->em->flush();
+
+        return $connection;
+    }
+
+    private function storeAccrualRaw(string $companyId, string $connectionRef, string $date, int $accrualId): IngestRawRecord
+    {
+        /** @var RawStorageFacade $rawStorageFacade */
+        $rawStorageFacade = self::getContainer()->get(RawStorageFacade::class);
+
+        $records = $rawStorageFacade->store(new RawBatch(
+            companyId: $companyId,
+            connectionRef: $connectionRef,
+            shopRef: $connectionRef,
+            source: IngestSource::OZON,
+            resourceType: OzonResourceType::ACCRUAL_BY_DAY,
+            externalId: sprintf('accrual-by-day:%s:%s', $date, $date),
+            syncJobId: Uuid::uuid7()->toString(),
+            fetchedAt: new \DateTimeImmutable(sprintf('%s 10:00:00+00:00', $date)),
+            rows: [[
+                'accrual_id' => $accrualId,
+                'date' => $date,
+                'accrued_category' => 'POSTING',
+                'posting' => [
+                    'products' => [[
+                        'commission' => [
+                            'sale_amount' => ['amount' => '100.00', 'currency' => 'RUB'],
+                            'commission' => ['amount' => '-10.00', 'currency' => 'RUB'],
+                        ],
+                    ]],
+                ],
+            ]],
+        ));
+        $this->em->flush();
+
+        return $records[0];
+    }
+
+    private function tester(string $commandName): CommandTester
+    {
+        $app = new Application(self::$kernel);
+
+        return new CommandTester($app->find($commandName));
+    }
+}


### PR DESCRIPTION
## What changed

- Added `app:ingestion:ozon-accrual:rolling-refresh` to dispatch rolling backfills for active Ozon seller shops.
- Added `app:ingestion:ozon-accrual:verify-rolling-refresh` for read-only parity checks between latest raw accrual coverage and canonical financial transactions.
- Skipped re-normalization for unchanged raw snapshots that are already `DONE`, so same-hash refreshes only mark raw as seen.
- Scheduled daily cron runs for refresh and post-normalization verification.
- Added integration coverage for rolling refresh, verification, and unchanged-hash normalization behavior.

## Why

Ozon accrual data can change retroactively, and a high-volume cabinet exposed that one-off backfills are not enough. The Ingestion pipeline should regularly refresh the latest window, normalize only changed payloads, and verify parity automatically.

## Validation

- `make site-test-unit` — passed: 1232 tests, 7546 assertions; existing 1 warning and 1 deprecation remain.
- `docker compose run --rm -T -e COMPOSER_PROCESS_TIMEOUT=0 site-php-cli php bin/phpunit -c phpunit.xml --testsuite=integration --filter 'OzonAccrualRollingRefreshCommandTest|OzonAccrualVerifyRollingRefreshCommandTest|OzonIngestionFlowTest'` — passed: 9 tests, 46 assertions; PHPUnit deprecations remain.
- `php -l` for changed/new command files — passed.
- `git diff --check` for scoped files — clean.

## Notes

- This PR intentionally touches only Ingestion refresh/verification plus cron wiring.
- Existing unrelated local docs/UI-kit worktree changes were not staged or included.
