### PR TITLE
[codex] Fix WB finance month recovery

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinancialReportPeriodResolver.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportPeriodResolver.php
@@ -32,6 +32,13 @@ final class WbFinancialReportPeriodResolver
         return $now->setDate((int) $now->format('Y'), 1, 1);
     }
 
+    public function currentMonthStart(): DateTimeImmutable
+    {
+        $now = $this->nowInBusinessTimezone();
+
+        return $now->setDate((int) $now->format('Y'), (int) $now->format('n'), 1);
+    }
+
     /**
      * @return list<DateTimeImmutable>
      */

--- a/site/src/Marketplace/Command/WbFinancialReportsOrchestrateCommand.php
+++ b/site/src/Marketplace/Command/WbFinancialReportsOrchestrateCommand.php
@@ -117,8 +117,6 @@ final class WbFinancialReportsOrchestrateCommand extends Command
 
                 if (null !== $connectionCooldownUntil) {
                     $reason = 'connection cooldown until '.$connectionCooldownUntil->format(\DateTimeInterface::ATOM);
-                } elseif ($futureQueuedCount > 0) {
-                    $reason = 'queued future retry exists in recovery window';
                 } else {
                     if (self::MODE_HISTORICAL_RECOVERY !== $mode) {
                         $dailyStatus = $this->findDailyStatus($companyIdValue, $connectionIdValue, $yesterday);
@@ -127,41 +125,49 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                             $action = $dispatched > 0 ? 'daily yesterday' : 'daily skipped by claim';
                             $reason = $dispatched > 0 ? 'planned' : 'status not claimable';
                         }
+                    }
 
-                        if (0 === $dispatched && $recoveryDueRetryCount > 0) {
-                            $dispatched = $this->planner->planDueRetry($companyIdValue, $connectionIdValue, 1, $recoveryFrom, $yesterday);
-                            $action = $dispatched > 0 ? 'recovery due retry' : 'recovery due retry skipped by claim';
+                    if (0 === $dispatched && $futureQueuedCount > 0) {
+                        if ('skipped' === $action) {
+                            $reason = 'queued future retry exists in recovery window';
+                        }
+                    } else {
+                        if (self::MODE_HISTORICAL_RECOVERY !== $mode) {
+                            if (0 === $dispatched && $recoveryDueRetryCount > 0) {
+                                $dispatched = $this->planner->planDueRetry($companyIdValue, $connectionIdValue, 1, $recoveryFrom, $yesterday);
+                                $action = $dispatched > 0 ? 'recovery due retry' : 'recovery due retry skipped by claim';
+                                $reason = $dispatched > 0 ? 'planned' : 'status not claimable';
+                            }
+
+                            if (0 === $dispatched && 0 === $recoveryDueRetryCount && $recoveryMissingCount > 0) {
+                                $dispatched = $this->planner->planMissing($companyIdValue, $connectionIdValue, 1, $recoveryFrom, $yesterday);
+                                if ($dispatched > 0) {
+                                    $action = 'recovery missing';
+                                    $reason = 'planned';
+                                }
+                            }
+
+                            if (0 === $dispatched && 0 === $recoveryDueRetryCount && 0 === $recoveryMissingCount) {
+                                $dispatched = $this->planner->planRefreshRecentDays($companyIdValue, $connectionIdValue, $refreshDaysBack, 1);
+                                if ($dispatched > 0) {
+                                    $action = 'refresh last '.$refreshDaysBack.' days';
+                                    $reason = 'planned';
+                                }
+                            }
+                        }
+
+                        if (0 === $dispatched && $includeHistoricalRetry && $historicalDueRetryCount > 0) {
+                            $dispatched = $this->planner->planDueRetry($companyIdValue, $connectionIdValue, $historicalMaxDays, $currentYearStart, $historicalTo);
+                            $action = $dispatched > 0 ? 'historical due retry' : 'historical due retry skipped by claim';
                             $reason = $dispatched > 0 ? 'planned' : 'status not claimable';
                         }
 
-                        if (0 === $dispatched && 0 === $recoveryDueRetryCount && $recoveryMissingCount > 0) {
-                            $dispatched = $this->planner->planMissing($companyIdValue, $connectionIdValue, 1, $recoveryFrom, $yesterday);
+                        if (0 === $dispatched && $includeHistoricalRetry && 0 === $historicalDueRetryCount && $historicalMissingCount > 0) {
+                            $dispatched = $this->planner->planMissing($companyIdValue, $connectionIdValue, $historicalMaxDays, $currentYearStart, $historicalTo);
                             if ($dispatched > 0) {
-                                $action = 'recovery missing';
+                                $action = 'historical missing';
                                 $reason = 'planned';
                             }
-                        }
-
-                        if (0 === $dispatched && 0 === $recoveryDueRetryCount && 0 === $recoveryMissingCount) {
-                            $dispatched = $this->planner->planRefreshRecentDays($companyIdValue, $connectionIdValue, $refreshDaysBack, 1);
-                            if ($dispatched > 0) {
-                                $action = 'refresh last '.$refreshDaysBack.' days';
-                                $reason = 'planned';
-                            }
-                        }
-                    }
-
-                    if (0 === $dispatched && $includeHistoricalRetry && $historicalDueRetryCount > 0) {
-                        $dispatched = $this->planner->planDueRetry($companyIdValue, $connectionIdValue, $historicalMaxDays, $currentYearStart, $historicalTo);
-                        $action = $dispatched > 0 ? 'historical due retry' : 'historical due retry skipped by claim';
-                        $reason = $dispatched > 0 ? 'planned' : 'status not claimable';
-                    }
-
-                    if (0 === $dispatched && $includeHistoricalRetry && 0 === $historicalDueRetryCount && $historicalMissingCount > 0) {
-                        $dispatched = $this->planner->planMissing($companyIdValue, $connectionIdValue, $historicalMaxDays, $currentYearStart, $historicalTo);
-                        if ($dispatched > 0) {
-                            $action = 'historical missing';
-                            $reason = 'planned';
                         }
                     }
                 }

--- a/site/src/Marketplace/Command/WbFinancialReportsOrchestrateCommand.php
+++ b/site/src/Marketplace/Command/WbFinancialReportsOrchestrateCommand.php
@@ -50,8 +50,8 @@ final class WbFinancialReportsOrchestrateCommand extends Command
             ->addOption('company-id', null, InputOption::VALUE_OPTIONAL)
             ->addOption('connection-id', null, InputOption::VALUE_OPTIONAL)
             ->addOption('refresh-days-back', null, InputOption::VALUE_OPTIONAL, 'Refresh only the last N business days before today.', '2')
-            ->addOption('retry-window-days', null, InputOption::VALUE_OPTIONAL, 'Operational retry/missing window in days before today.', '14')
-            ->addOption('include-historical-retry', null, InputOption::VALUE_NONE, 'Allow due retries and missing days older than retry-window-days.')
+            ->addOption('retry-window-days', null, InputOption::VALUE_OPTIONAL, 'Deprecated compatibility option; operational recovery uses current month-to-date.', '14')
+            ->addOption('include-historical-retry', null, InputOption::VALUE_NONE, 'Allow due retries and missing days older than current month-to-date.')
             ->addOption('historical-max-days', null, InputOption::VALUE_OPTIONAL, 'Maximum historical days to schedule per connection when history is explicitly enabled.', '1')
             ->addOption('mode', null, InputOption::VALUE_OPTIONAL, 'Run mode: operational or historical-recovery.', self::MODE_OPERATIONAL);
     }
@@ -70,7 +70,6 @@ final class WbFinancialReportsOrchestrateCommand extends Command
             $companyId = $this->normalizeOptional((string) $input->getOption('company-id'));
             $connectionId = $this->normalizeOptional((string) $input->getOption('connection-id'));
             $refreshDaysBack = max(1, (int) $input->getOption('refresh-days-back'));
-            $retryWindowDays = max(1, (int) $input->getOption('retry-window-days'));
             $historicalMaxDays = max(1, (int) $input->getOption('historical-max-days'));
             $mode = (string) $input->getOption('mode');
             if (!\in_array($mode, [self::MODE_OPERATIONAL, self::MODE_HISTORICAL_RECOVERY], true)) {
@@ -87,11 +86,9 @@ final class WbFinancialReportsOrchestrateCommand extends Command
             }
             $yesterday = $this->periodResolver->yesterday();
             $currentYearStart = $this->periodResolver->currentYearStart();
-            $retryWindowStart = $this->periodResolver->lastDays($retryWindowDays)[0];
-            if ($retryWindowStart < $currentYearStart) {
-                $retryWindowStart = $currentYearStart;
-            }
-            $historicalTo = $retryWindowStart->modify('-1 day');
+            $recoveryFrom = $this->periodResolver->currentMonthStart();
+            $hasRecoveryWindow = $recoveryFrom <= $yesterday;
+            $historicalTo = $hasRecoveryWindow ? $recoveryFrom->modify('-1 day') : $yesterday;
 
             foreach ($this->activeWbConnectionsQuery->execute($companyId, $connectionId) as $activeConnection) {
                 $connectionIdValue = (string) $activeConnection['connection_id'];
@@ -102,20 +99,26 @@ final class WbFinancialReportsOrchestrateCommand extends Command
 
                 $connectionCooldownUntil = $this->rateLimiter->getActiveSalesReportsCooldownUntil('connection:'.$connectionIdValue);
 
-                $recentDueRetryCount = $this->countDueRetry($companyIdValue, $connectionIdValue, $retryWindowStart, $yesterday);
+                $recoveryDueRetryCount = $hasRecoveryWindow
+                    ? $this->countDueRetry($companyIdValue, $connectionIdValue, $recoveryFrom, $yesterday)
+                    : 0;
                 $historicalDueRetryCount = $historicalTo >= $currentYearStart
                     ? $this->countDueRetry($companyIdValue, $connectionIdValue, $currentYearStart, $historicalTo)
                     : 0;
-                $recentMissingCount = $this->countMissing($companyIdValue, $connectionIdValue, $retryWindowStart, $yesterday);
+                $recoveryMissingCount = $hasRecoveryWindow
+                    ? $this->countMissing($companyIdValue, $connectionIdValue, $recoveryFrom, $yesterday)
+                    : 0;
                 $historicalMissingCount = $historicalTo >= $currentYearStart
                     ? $this->countMissing($companyIdValue, $connectionIdValue, $currentYearStart, $historicalTo)
                     : 0;
-                $futureQueuedCount = $this->countFutureQueued($companyIdValue, $connectionIdValue, $retryWindowStart, $yesterday);
+                $futureQueuedCount = $hasRecoveryWindow
+                    ? $this->countFutureQueued($companyIdValue, $connectionIdValue, $recoveryFrom, $yesterday)
+                    : 0;
 
                 if (null !== $connectionCooldownUntil) {
                     $reason = 'connection cooldown until '.$connectionCooldownUntil->format(\DateTimeInterface::ATOM);
                 } elseif ($futureQueuedCount > 0) {
-                    $reason = 'queued future retry exists in operational window';
+                    $reason = 'queued future retry exists in recovery window';
                 } else {
                     if (self::MODE_HISTORICAL_RECOVERY !== $mode) {
                         $dailyStatus = $this->findDailyStatus($companyIdValue, $connectionIdValue, $yesterday);
@@ -125,23 +128,24 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                             $reason = $dispatched > 0 ? 'planned' : 'status not claimable';
                         }
 
-                        if (0 === $dispatched && $recentDueRetryCount > 0) {
-                            $dispatched = $this->planner->planDueRetry($companyIdValue, $connectionIdValue, 1, $retryWindowStart, $yesterday);
-                            $action = $dispatched > 0 ? 'recent due retry' : 'recent due retry skipped by claim';
+                        if (0 === $dispatched && $recoveryDueRetryCount > 0) {
+                            $dispatched = $this->planner->planDueRetry($companyIdValue, $connectionIdValue, 1, $recoveryFrom, $yesterday);
+                            $action = $dispatched > 0 ? 'recovery due retry' : 'recovery due retry skipped by claim';
                             $reason = $dispatched > 0 ? 'planned' : 'status not claimable';
                         }
-                        if (0 === $dispatched && 0 === $recentDueRetryCount) {
-                            $dispatched = $this->planner->planRefreshRecentDays($companyIdValue, $connectionIdValue, $refreshDaysBack, 1);
+
+                        if (0 === $dispatched && 0 === $recoveryDueRetryCount && $recoveryMissingCount > 0) {
+                            $dispatched = $this->planner->planMissing($companyIdValue, $connectionIdValue, 1, $recoveryFrom, $yesterday);
                             if ($dispatched > 0) {
-                                $action = 'refresh last '.$refreshDaysBack.' days';
+                                $action = 'recovery missing';
                                 $reason = 'planned';
                             }
                         }
 
-                        if (0 === $dispatched && 0 === $recentDueRetryCount && $recentMissingCount > 0) {
-                            $dispatched = $this->planner->planMissing($companyIdValue, $connectionIdValue, 1, $retryWindowStart, $yesterday);
+                        if (0 === $dispatched && 0 === $recoveryDueRetryCount && 0 === $recoveryMissingCount) {
+                            $dispatched = $this->planner->planRefreshRecentDays($companyIdValue, $connectionIdValue, $refreshDaysBack, 1);
                             if ($dispatched > 0) {
-                                $action = 'recent missing';
+                                $action = 'refresh last '.$refreshDaysBack.' days';
                                 $reason = 'planned';
                             }
                         }
@@ -169,9 +173,9 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                     $action,
                     (string) $dispatched,
                     $reason,
-                    (string) $recentDueRetryCount,
+                    (string) $recoveryDueRetryCount,
                     (string) $historicalDueRetryCount,
-                    (string) $recentMissingCount,
+                    (string) $recoveryMissingCount,
                     (string) $historicalMissingCount,
                 ];
             }
@@ -182,9 +186,9 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                 'action',
                 'dispatched',
                 'reason',
-                'recent_due_retry_count',
+                'recovery_due_retry_count',
                 'historical_due_retry_count',
-                'recent_missing_count',
+                'recovery_missing_count',
                 'historical_missing_count',
             ], $rows);
             $io->success(sprintf('WB finance orchestration completed. Dispatched %d task(s).', $totalDispatched));

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportPeriodResolverTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportPeriodResolverTest.php
@@ -33,6 +33,13 @@ final class WbFinancialReportPeriodResolverTest extends TestCase
         self::assertSame('2026-01-01 00:00:00 Europe/Moscow', $resolver->currentYearStart()->format('Y-m-d H:i:s e'));
     }
 
+    public function testCurrentMonthStartUsesCurrentBusinessMonth(): void
+    {
+        $resolver = new WbFinancialReportPeriodResolver(new MockClock('2026-05-20 12:00:00 Europe/Moscow'));
+
+        self::assertSame('2026-05-01 00:00:00 Europe/Moscow', $resolver->currentMonthStart()->format('Y-m-d H:i:s e'));
+    }
+
     public function testLast14DaysReturnsFourteenDatesIncludingYesterday(): void
     {
         $resolver = new WbFinancialReportPeriodResolver(new MockClock('2026-05-20 12:00:00 Europe/Moscow'));

--- a/site/tests/Unit/Marketplace/Command/WbFinancialReportsOrchestrateCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/WbFinancialReportsOrchestrateCommandTest.php
@@ -66,6 +66,40 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $this->execute($rateLimiter));
     }
 
+    public function testFutureQueuedRecoveryRowDoesNotBlockDailyYesterday(): void
+    {
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
+            ['company-a:conn-a' => null],
+            [],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 1],
+        ));
+        $this->planner->expects(self::once())->method('planDaily')->with('company-a', 'conn-a', false)->willReturn(1);
+        $this->planner->expects(self::never())->method('planDueRetry');
+        $this->planner->expects(self::never())->method('planMissing');
+        $this->planner->expects(self::never())->method('planRefreshRecentDays');
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter()));
+    }
+
+    public function testFutureQueuedRecoveryRowStillBlocksRecoveryAfterDailyComplete(): void
+    {
+        $tester = null;
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
+            ['company-a:conn-a' => 'success'],
+            [],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 1],
+        ));
+        $this->planner->expects(self::never())->method('planDaily');
+        $this->planner->expects(self::never())->method('planDueRetry');
+        $this->planner->expects(self::never())->method('planMissing');
+        $this->planner->expects(self::never())->method('planRefreshRecentDays');
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter(), [], $tester));
+        self::assertStringContainsString('queued future retry exists in recovery window', $tester->getDisplay());
+    }
+
     public function testDailyStatusIsReadOnlyForDailyMode(): void
     {
         $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);

--- a/site/tests/Unit/Marketplace/Command/WbFinancialReportsOrchestrateCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/WbFinancialReportsOrchestrateCommandTest.php
@@ -77,6 +77,9 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
 
                 return 'success';
             }
+            if (str_contains($sql, 'COUNT(DISTINCT business_date)')) {
+                return 20;
+            }
 
             return 0;
         });
@@ -118,6 +121,9 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
             if (str_contains($sql, "status = 'queued'") && str_contains($sql, 'next_retry_at > NOW()')) {
                 return 0;
             }
+            if (str_contains($sql, 'COUNT(DISTINCT business_date)')) {
+                return 20;
+            }
             if (str_contains($sql, "status IN ('queued', 'failed')")) {
                 ++$dueRetrySqlAssertions;
                 self::assertStringContainsString('last_error_class = :rateLimitErrorClass', $sql);
@@ -135,18 +141,24 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
         self::assertSame(2, $dueRetrySqlAssertions);
     }
 
-    public function testOldDueRetryOutsideDefaultWindowFallsThroughToRefresh(): void
+    public function testCurrentMonthDueRetryOutsideLegacyWindowRunsBeforeRefresh(): void
     {
         $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
         $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
             ['company-a:conn-a' => 'success'],
-            ['company-a:conn-a:2026-05-07:2026-05-20' => 0, 'company-a:conn-a:2026-01-01:2026-05-06' => 1],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 1],
         ));
-        $this->planner->expects(self::never())->method('planDueRetry');
-        $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(1);
+        $this->planner->expects(self::once())->method('planDueRetry')->with(
+            'company-a',
+            'conn-a',
+            1,
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-01' === $date->format('Y-m-d')),
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-20' === $date->format('Y-m-d')),
+        )->willReturn(1);
+        $this->planner->expects(self::never())->method('planRefreshRecentDays');
         $this->planner->expects(self::never())->method('planMissing');
 
-        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter()));
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter(), ['--retry-window-days' => '7']));
     }
 
     public function testRecentDueRetryInsideWindowRunsBeforeRefresh(): void
@@ -154,13 +166,13 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
         $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
         $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
             ['company-a:conn-a' => 'success'],
-            ['company-a:conn-a:2026-05-07:2026-05-20' => 1],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 1],
         ));
         $this->planner->expects(self::once())->method('planDueRetry')->with(
             'company-a',
             'conn-a',
             1,
-            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-07' === $date->format('Y-m-d')),
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-01' === $date->format('Y-m-d')),
             self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-20' === $date->format('Y-m-d')),
         )->willReturn(1);
         $this->planner->expects(self::never())->method('planRefreshRecentDays');
@@ -174,7 +186,7 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
         $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
         $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
             ['company-a:conn-a' => 'success'],
-            ['company-a:conn-a:2026-05-07:2026-05-20' => 0, 'company-a:conn-a:2026-01-01:2026-05-06' => 1],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 0, 'company-a:conn-a:2026-01-01:2026-04-30' => 1],
         ));
         $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(0);
         $this->planner->expects(self::once())->method('planDueRetry')->with(
@@ -182,7 +194,7 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
             'conn-a',
             1,
             self::callback(static fn (\DateTimeImmutable $date): bool => '2026-01-01' === $date->format('Y-m-d')),
-            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-06' === $date->format('Y-m-d')),
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-04-30' === $date->format('Y-m-d')),
         )->willReturn(1);
         $this->planner->expects(self::never())->method('planMissing');
 
@@ -194,7 +206,7 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
         $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
         $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
             ['company-a:conn-a' => 'success'],
-            ['company-a:conn-a:2026-05-07:2026-05-20' => 0, 'company-a:conn-a:2026-01-01:2026-05-06' => 1],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 0, 'company-a:conn-a:2026-01-01:2026-04-30' => 1],
         ));
         $this->planner->expects(self::never())->method('planDueRetry');
         $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(1);
@@ -209,16 +221,16 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
         $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
         $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
             ['company-a:conn-a' => 'success'],
-            ['company-a:conn-a:2026-05-07:2026-05-20' => 1],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 1],
             [],
-            ['company-a:conn-a:2026-05-07:2026-05-20' => 13],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 19],
         ));
         $this->planner->expects(self::once())->method('planDueRetry')->willReturn(0);
         $this->planner->expects(self::never())->method('planRefreshRecentDays');
         $this->planner->expects(self::never())->method('planMissing');
 
         self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter(), [], $tester));
-        self::assertStringContainsString('recent due retry skipped by claim', $tester->getDisplay());
+        self::assertStringContainsString('recovery due retry skipped by claim', $tester->getDisplay());
         self::assertStringContainsString('Dispatched 0 task(s).', $tester->getDisplay());
     }
 
@@ -228,9 +240,9 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
         $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
         $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
             ['company-a:conn-a' => 'success'],
-            ['company-a:conn-a:2026-05-07:2026-05-20' => 0, 'company-a:conn-a:2026-01-01:2026-05-06' => 1],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 0, 'company-a:conn-a:2026-01-01:2026-04-30' => 1],
             [],
-            ['company-a:conn-a:2026-01-01:2026-05-06' => 0],
+            ['company-a:conn-a:2026-01-01:2026-04-30' => 0],
         ));
         $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(0);
         $this->planner->expects(self::once())->method('planDueRetry')->with(
@@ -238,7 +250,7 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
             'conn-a',
             1,
             self::callback(static fn (\DateTimeImmutable $date): bool => '2026-01-01' === $date->format('Y-m-d')),
-            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-06' === $date->format('Y-m-d')),
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-04-30' === $date->format('Y-m-d')),
         )->willReturn(0);
         $this->planner->expects(self::never())->method('planMissing');
 
@@ -252,29 +264,57 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
         $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
         $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
             ['company-a:conn-a' => 'success'],
-            ['company-a:conn-a:2026-05-07:2026-05-20' => 0],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 0],
             [],
-            ['company-a:conn-a:2026-05-07:2026-05-20' => 13],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 19],
         ));
         $this->planner->expects(self::never())->method('planDueRetry');
-        $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(0);
+        $this->planner->expects(self::never())->method('planRefreshRecentDays');
         $this->planner->expects(self::once())->method('planMissing')->with(
             'company-a',
             'conn-a',
             1,
-            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-07' === $date->format('Y-m-d')),
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-01' === $date->format('Y-m-d')),
             self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-20' === $date->format('Y-m-d')),
         )->willReturn(1);
 
         self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter()));
     }
 
-    private function execute(WbFinanceRateLimiter $rateLimiter, array $input = [], ?CommandTester &$tester = null): int
+    public function testFirstBusinessDayOfMonthDoesNotQueryEmptyRecoveryWindow(): void
+    {
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $this->db->method('fetchOne')->willReturnCallback(static function (string $sql, array $params = []): mixed {
+            self::assertFalse(
+                ($params['fromDate'] ?? null) === '2026-06-01' && ($params['toDate'] ?? null) === '2026-05-31',
+                'Recovery range must not be queried when current month start is after yesterday.',
+            );
+
+            if (str_contains($sql, 'AND business_date = :businessDate')) {
+                return 'success';
+            }
+            if (str_contains($sql, 'COUNT(DISTINCT business_date)')) {
+                $from = new \DateTimeImmutable((string) $params['fromDate']);
+                $to = new \DateTimeImmutable((string) $params['toDate']);
+
+                return $from->diff($to)->days + 1;
+            }
+
+            return 0;
+        });
+        $this->planner->expects(self::never())->method('planDueRetry');
+        $this->planner->expects(self::never())->method('planMissing');
+        $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(1);
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter(), [], now: '2026-06-01 00:00:00 Europe/Moscow'));
+    }
+
+    private function execute(WbFinanceRateLimiter $rateLimiter, array $input = [], ?CommandTester &$tester = null, string $now = '2026-05-21 00:00:00 Europe/Moscow'): int
     {
         $command = new WbFinancialReportsOrchestrateCommand(
             $this->connections,
             $rateLimiter,
-            new WbFinancialReportPeriodResolver(new MockClock('2026-05-21 00:00:00 Europe/Moscow')),
+            new WbFinancialReportPeriodResolver(new MockClock($now)),
             $this->planner,
             $this->db,
             $this->logger,


### PR DESCRIPTION
## Summary

Fixes WB financial reports orchestration in the legacy Marketplace module so operational recovery covers the current month-to-date instead of the previous 14-day window.

## Root Cause

The orchestrator planned work in this order: daily, due retry, recent refresh, missing. With hourly refresh jobs, missing days could be starved by refresh tasks and then age out of the operational window. The rate limiter is already connection/store-scoped, so the issue was not IP-global throttling.

## Changes

- Add `currentMonthStart()` to `WbFinancialReportPeriodResolver`.
- Use current month start through yesterday as the operational recovery window.
- Keep `--retry-window-days` accepted for compatibility, but mark it deprecated in help text.
- Reorder per-connection planning to: daily yesterday, recovery due retry, recovery missing, refresh.
- Keep `daily yesterday` ahead of the future-queued recovery guard so stale early-month retry backoff cannot block the freshest daily sync.
- Guard the first business day of a month from querying an invalid empty recovery range.
- Update unit tests around month-to-date recovery, missing-before-refresh, historical window boundaries, future-queued guard behavior, and first-day-of-month behavior.

## Scope

Only legacy Marketplace WB financial report orchestration and its unit tests were changed. No cron, Messenger routing, database migrations, public APIs, or ingestion module files were changed.

## Validation

- `docker compose run --rm -T site-php-cli php bin/phpunit --filter 'WbFinancialReportsOrchestrateCommandTest|WbFinancialReportPeriodResolverTest'` — passed, 25 tests.
- `make site-test-unit` — passed, 1236 tests.
- `git diff --check` — passed.
- Follow-up review — no actionable correctness issues found.

`make site-test-unit` still reports one existing warning in `StorageServiceTest` and one existing deprecation in `XlsxReaderServiceTest`; both are outside this change.