### PR TITLE
[codex] Recover empty WB finance days

### DIFF
--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
@@ -197,6 +197,61 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
         return $dispatched;
     }
 
+    public function planEmptyRefresh(
+        ?string $companyId = null,
+        ?string $connectionId = null,
+        int $maxDays = 1,
+        ?DateTimeImmutable $from = null,
+        ?DateTimeImmutable $to = null,
+        int $maxAttempts = 5,
+    ): int {
+        if ($maxDays <= 0 || $maxAttempts <= 0) {
+            return 0;
+        }
+
+        $dispatched = 0;
+        $from ??= $this->periodResolver->currentMonthStart();
+        $to ??= $this->periodResolver->yesterday();
+
+        foreach ($this->activeConnections($companyId, $connectionId) as $connection) {
+            $statuses = $this->syncStatusRepository->findStatusesForDateRange(
+                $connection['company_id'],
+                $connection['connection_id'],
+                MarketplaceType::WILDBERRIES,
+                self::REPORT_TYPE,
+                $from,
+                $to,
+            );
+
+            $emptyDays = [];
+            foreach ($statuses as $status) {
+                if (FinancialReportSyncStatus::EMPTY !== $status->getStatus() || $status->getAttempts() >= $maxAttempts) {
+                    continue;
+                }
+
+                $emptyDays[] = $status->getBusinessDate();
+            }
+
+            usort($emptyDays, static fn (DateTimeImmutable $a, DateTimeImmutable $b): int => $a->getTimestamp() <=> $b->getTimestamp());
+
+            $scheduledForConnection = 0;
+            foreach ($emptyDays as $day) {
+                if ($scheduledForConnection >= $maxDays) {
+                    break;
+                }
+
+                if (!$this->claimAndDispatch($connection['company_id'], $connection['connection_id'], $day, FinancialReportSyncMode::REFRESH_14D, true)) {
+                    continue;
+                }
+
+                ++$dispatched;
+                ++$scheduledForConnection;
+            }
+        }
+
+        return $dispatched;
+    }
+
 
     /**
      * @deprecated Use planRangeLimited() from console commands. planRange() schedules full explicit range without dispatch limit.

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlanner.php
@@ -229,17 +229,28 @@ final class WbFinancialReportSyncPlanner implements WbFinancialReportSyncPlanner
                     continue;
                 }
 
-                $emptyDays[] = $status->getBusinessDate();
+                $emptyDays[] = [
+                    'day' => $status->getBusinessDate(),
+                    'updated_at' => $status->getUpdatedAt(),
+                ];
             }
 
-            usort($emptyDays, static fn (DateTimeImmutable $a, DateTimeImmutable $b): int => $a->getTimestamp() <=> $b->getTimestamp());
+            usort($emptyDays, static function (array $a, array $b): int {
+                $updatedAtCompare = $a['updated_at']->getTimestamp() <=> $b['updated_at']->getTimestamp();
+                if (0 !== $updatedAtCompare) {
+                    return $updatedAtCompare;
+                }
+
+                return $a['day']->getTimestamp() <=> $b['day']->getTimestamp();
+            });
 
             $scheduledForConnection = 0;
-            foreach ($emptyDays as $day) {
+            foreach ($emptyDays as $emptyDay) {
                 if ($scheduledForConnection >= $maxDays) {
                     break;
                 }
 
+                $day = $emptyDay['day'];
                 if (!$this->claimAndDispatch($connection['company_id'], $connection['connection_id'], $day, FinancialReportSyncMode::REFRESH_14D, true)) {
                     continue;
                 }

--- a/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlannerInterface.php
+++ b/site/src/Marketplace/Application/Service/WbFinancialReportSyncPlannerInterface.php
@@ -17,6 +17,15 @@ interface WbFinancialReportSyncPlannerInterface
 
     public function planDueRetry(?string $companyId = null, ?string $connectionId = null, int $maxDays = 1, ?DateTimeImmutable $from = null, ?DateTimeImmutable $to = null): int;
 
+    public function planEmptyRefresh(
+        ?string $companyId = null,
+        ?string $connectionId = null,
+        int $maxDays = 1,
+        ?DateTimeImmutable $from = null,
+        ?DateTimeImmutable $to = null,
+        int $maxAttempts = 5,
+    ): int;
+
     /**
      * @deprecated Use planRangeLimited() from console commands. planRange() schedules full explicit range without dispatch limit.
      */

--- a/site/src/Marketplace/Command/WbFinancialReportsOrchestrateCommand.php
+++ b/site/src/Marketplace/Command/WbFinancialReportsOrchestrateCommand.php
@@ -32,6 +32,7 @@ final class WbFinancialReportsOrchestrateCommand extends Command
     private const GLOBAL_BUCKET = 'global';
     private const MODE_OPERATIONAL = 'operational';
     private const MODE_HISTORICAL_RECOVERY = 'historical-recovery';
+    private const EMPTY_REFRESH_MAX_ATTEMPTS = 5;
 
     public function __construct(
         private readonly ActiveWbConnectionsQuery $activeWbConnectionsQuery,
@@ -108,6 +109,9 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                 $recoveryMissingCount = $hasRecoveryWindow
                     ? $this->countMissing($companyIdValue, $connectionIdValue, $recoveryFrom, $yesterday)
                     : 0;
+                $recoveryEmptyCount = $hasRecoveryWindow
+                    ? $this->countRetryableEmpty($companyIdValue, $connectionIdValue, $recoveryFrom, $yesterday)
+                    : 0;
                 $historicalMissingCount = $historicalTo >= $currentYearStart
                     ? $this->countMissing($companyIdValue, $connectionIdValue, $currentYearStart, $historicalTo)
                     : 0;
@@ -147,7 +151,20 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                                 }
                             }
 
-                            if (0 === $dispatched && 0 === $recoveryDueRetryCount && 0 === $recoveryMissingCount) {
+                            if (0 === $dispatched && 0 === $recoveryDueRetryCount && 0 === $recoveryMissingCount && $recoveryEmptyCount > 0) {
+                                $dispatched = $this->planner->planEmptyRefresh(
+                                    $companyIdValue,
+                                    $connectionIdValue,
+                                    1,
+                                    $recoveryFrom,
+                                    $yesterday,
+                                    self::EMPTY_REFRESH_MAX_ATTEMPTS,
+                                );
+                                $action = $dispatched > 0 ? 'recovery empty refresh' : 'recovery empty skipped by claim';
+                                $reason = $dispatched > 0 ? 'planned' : 'status not claimable';
+                            }
+
+                            if (0 === $dispatched && 0 === $recoveryDueRetryCount && 0 === $recoveryMissingCount && 0 === $recoveryEmptyCount) {
                                 $dispatched = $this->planner->planRefreshRecentDays($companyIdValue, $connectionIdValue, $refreshDaysBack, 1);
                                 if ($dispatched > 0) {
                                     $action = 'refresh last '.$refreshDaysBack.' days';
@@ -182,6 +199,7 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                     (string) $recoveryDueRetryCount,
                     (string) $historicalDueRetryCount,
                     (string) $recoveryMissingCount,
+                    (string) $recoveryEmptyCount,
                     (string) $historicalMissingCount,
                 ];
             }
@@ -195,6 +213,7 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                 'recovery_due_retry_count',
                 'historical_due_retry_count',
                 'recovery_missing_count',
+                'recovery_empty_count',
                 'historical_missing_count',
             ], $rows);
             $io->success(sprintf('WB finance orchestration completed. Dispatched %d task(s).', $totalDispatched));
@@ -254,6 +273,29 @@ final class WbFinancialReportsOrchestrateCommand extends Command
                 'reportType' => self::REPORT_TYPE,
                 'fromDate' => $from->format('Y-m-d'),
                 'toDate' => $to->format('Y-m-d'),
+            ],
+        );
+    }
+
+    private function countRetryableEmpty(string $companyId, string $connectionId, \DateTimeImmutable $from, \DateTimeImmutable $to): int
+    {
+        return (int) $this->connection->fetchOne(
+            "SELECT COUNT(*)
+             FROM marketplace_financial_report_sync_statuses
+             WHERE company_id = :companyId
+               AND connection_id = :connectionId
+               AND marketplace = 'wildberries'
+               AND report_type = :reportType
+               AND business_date BETWEEN :fromDate AND :toDate
+               AND status = 'empty'
+               AND attempts < :maxAttempts",
+            [
+                'companyId' => $companyId,
+                'connectionId' => $connectionId,
+                'reportType' => self::REPORT_TYPE,
+                'fromDate' => $from->format('Y-m-d'),
+                'toDate' => $to->format('Y-m-d'),
+                'maxAttempts' => self::EMPTY_REFRESH_MAX_ATTEMPTS,
             ],
         );
     }

--- a/site/src/Marketplace/Controller/MarketplaceController.php
+++ b/site/src/Marketplace/Controller/MarketplaceController.php
@@ -87,7 +87,7 @@ class MarketplaceController extends AbstractController
             $row['status_enum'] = FinancialReportSyncStatus::from((string) $row['status']);
 
             return $row;
-        }, $this->wbFinanceSyncStatusListQuery->findRecentDays((string) $company->getId(), 14));
+        }, $this->wbFinanceSyncStatusListQuery->findCurrentMonthDays((string) $company->getId()));
 
         return $this->render('marketplace/index.html.twig', [
             'connections'           => $connections,

--- a/site/src/Marketplace/Infrastructure/Query/WbFinanceSyncStatusListQuery.php
+++ b/site/src/Marketplace/Infrastructure/Query/WbFinanceSyncStatusListQuery.php
@@ -69,4 +69,14 @@ final class WbFinanceSyncStatusListQuery
             ->executeQuery()
             ->fetchAllAssociative();
     }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    public function findCurrentMonthDays(string $companyId): array
+    {
+        return $this->createByCompanyQueryBuilder($companyId, new \DateTimeImmutable('first day of this month'))
+            ->executeQuery()
+            ->fetchAllAssociative();
+    }
 }

--- a/site/templates/marketplace/index.html.twig
+++ b/site/templates/marketplace/index.html.twig
@@ -156,7 +156,7 @@
             } %}
             <div class="card mb-3">
                 <div class="card-header">
-                    <h3 class="card-title mb-0">Загрузка отчётов WB (последние 14 дней)</h3>
+                    <h3 class="card-title mb-0">Загрузка отчётов WB (текущий месяц)</h3>
                 </div>
                 <div class="table-responsive">
                     <table class="table card-table table-vcenter">
@@ -213,7 +213,7 @@
         <div class="card">
             <div class="card-header d-flex align-items-center justify-content-between gap-3">
                 <div class="d-flex align-items-center gap-3">
-                    <h3 class="card-title mb-0">История синхронизаций</h3>
+                    <h3 class="card-title mb-0">История raw-документов</h3>
                     <form method="get" action="{{ path('marketplace_index') }}" class="d-flex align-items-center gap-2 mb-0">
                         <label for="sync-history-marketplace" class="form-label mb-0">Маркетплейсы</label>
                         <select id="sync-history-marketplace"

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -601,6 +601,43 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         self::assertSame('refresh_14d', $this->dispatchedMessages[0]->mode);
     }
 
+    public function testPlanEmptyRefreshForceRefreshesRetryableEmptyDaysOnly(): void
+    {
+        $planner = $this->planner();
+        $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
+        $this->statuses->method('findStatusesForDateRange')->willReturn([
+            $this->statusEntity('2026-05-18', FinancialReportSyncStatus::EMPTY, null, '2026-05-18T09:00:00+03:00', attempts: 5),
+            $this->statusEntity('2026-05-19', FinancialReportSyncStatus::SUCCESS, null, '2026-05-19T09:00:00+03:00'),
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::EMPTY, null, '2026-05-20T09:00:00+03:00', attempts: 2),
+        ]);
+        $this->claimForQueueCallback = function (
+            string $connectionId,
+            string $companyId,
+            MarketplaceType $marketplace,
+            string $reportType,
+            string $apiEndpoint,
+            \DateTimeImmutable $businessDate,
+            FinancialReportSyncMode $mode,
+            bool $forceRefresh,
+            \DateTimeImmutable $now,
+        ): MarketplaceFinancialReportSyncStatus {
+            self::assertSame(FinancialReportSyncMode::REFRESH_14D, $mode);
+            self::assertTrue($forceRefresh);
+
+            return $this->statusEntity(
+                $businessDate->format('Y-m-d'),
+                FinancialReportSyncStatus::QUEUED,
+                null,
+                $now->format(DATE_ATOM),
+            );
+        };
+
+        self::assertSame(1, $planner->planEmptyRefresh(null, null, 1, new \DateTimeImmutable('2026-05-01'), new \DateTimeImmutable('2026-05-20'), 5));
+        self::assertSame('2026-05-20', $this->dispatchedMessages[0]->businessDate);
+        self::assertSame('refresh_14d', $this->dispatchedMessages[0]->mode);
+        self::assertTrue($this->dispatchedMessages[0]->forceRefresh);
+    }
+
     private function planner(): WbFinancialReportSyncPlanner
     {
         return new WbFinancialReportSyncPlanner(
@@ -620,6 +657,7 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         ?int $nextRrdId = null,
         ?string $stagingRawDocumentId = null,
         ?FinancialReportSyncMode $mode = FinancialReportSyncMode::REFRESH_14D,
+        int $attempts = 0,
     ): MarketplaceFinancialReportSyncStatus&MockObject {
         $entity = $this->createMock(MarketplaceFinancialReportSyncStatus::class);
         $entity->method('getBusinessDate')->willReturn(new \DateTimeImmutable($day.' 00:00:00 Europe/Moscow'));
@@ -629,6 +667,7 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         $entity->method('getNextRrdId')->willReturn($nextRrdId);
         $entity->method('getStagingRawDocumentId')->willReturn($stagingRawDocumentId);
         $entity->method('getMode')->willReturn($mode);
+        $entity->method('getAttempts')->willReturn($attempts);
 
         return $entity;
     }

--- a/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
+++ b/site/tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php
@@ -606,9 +606,10 @@ final class WbFinancialReportSyncPlannerTest extends TestCase
         $planner = $this->planner();
         $this->connections->method('execute')->willReturn([$this->conn('c1', 'co1')]);
         $this->statuses->method('findStatusesForDateRange')->willReturn([
-            $this->statusEntity('2026-05-18', FinancialReportSyncStatus::EMPTY, null, '2026-05-18T09:00:00+03:00', attempts: 5),
+            $this->statusEntity('2026-05-17', FinancialReportSyncStatus::EMPTY, null, '2026-05-17T07:00:00+03:00', attempts: 5),
+            $this->statusEntity('2026-05-18', FinancialReportSyncStatus::EMPTY, null, '2026-05-20T09:00:00+03:00', attempts: 2),
             $this->statusEntity('2026-05-19', FinancialReportSyncStatus::SUCCESS, null, '2026-05-19T09:00:00+03:00'),
-            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::EMPTY, null, '2026-05-20T09:00:00+03:00', attempts: 2),
+            $this->statusEntity('2026-05-20', FinancialReportSyncStatus::EMPTY, null, '2026-05-18T09:00:00+03:00', attempts: 2),
         ]);
         $this->claimForQueueCallback = function (
             string $connectionId,

--- a/site/tests/Unit/Marketplace/Command/WbFinancialReportsOrchestrateCommandTest.php
+++ b/site/tests/Unit/Marketplace/Command/WbFinancialReportsOrchestrateCommandTest.php
@@ -315,6 +315,47 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
         self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter()));
     }
 
+    public function testRecoveryEmptyRefreshRunsBeforeRecentRefresh(): void
+    {
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
+            ['company-a:conn-a' => 'success'],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 0],
+            [],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 20],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 2],
+        ));
+        $this->planner->expects(self::never())->method('planDueRetry');
+        $this->planner->expects(self::never())->method('planMissing');
+        $this->planner->expects(self::never())->method('planRefreshRecentDays');
+        $this->planner->expects(self::once())->method('planEmptyRefresh')->with(
+            'company-a',
+            'conn-a',
+            1,
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-01' === $date->format('Y-m-d')),
+            self::callback(static fn (\DateTimeImmutable $date): bool => '2026-05-20' === $date->format('Y-m-d')),
+            5,
+        )->willReturn(1);
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter()));
+    }
+
+    public function testRecentRefreshRunsWhenRetryableEmptyRowsDoNotExist(): void
+    {
+        $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
+        $this->db->method('fetchOne')->willReturnCallback($this->dbFetchOneCallback(
+            ['company-a:conn-a' => 'success'],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 0],
+            [],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 20],
+            ['company-a:conn-a:2026-05-01:2026-05-20' => 0],
+        ));
+        $this->planner->expects(self::never())->method('planEmptyRefresh');
+        $this->planner->expects(self::once())->method('planRefreshRecentDays')->with('company-a', 'conn-a', 2, 1)->willReturn(1);
+
+        self::assertSame(Command::SUCCESS, $this->execute($this->rateLimiter()));
+    }
+
     public function testFirstBusinessDayOfMonthDoesNotQueryEmptyRecoveryWindow(): void
     {
         $this->connections->method('execute')->willReturn([$this->conn('conn-a', 'company-a')]);
@@ -364,10 +405,11 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
      * @param array<string, int> $dueRetryCounts keyed by company:connection or company:connection:from:to
      * @param array<string, int> $futureQueuedCounts
      * @param array<string, int> $knownDayCounts keyed by company:connection or company:connection:from:to
+     * @param array<string, int> $emptyCounts keyed by company:connection or company:connection:from:to
      */
-    private function dbFetchOneCallback(array $dailyStatuses, array $dueRetryCounts = [], array $futureQueuedCounts = [], array $knownDayCounts = []): \Closure
+    private function dbFetchOneCallback(array $dailyStatuses, array $dueRetryCounts = [], array $futureQueuedCounts = [], array $knownDayCounts = [], array $emptyCounts = []): \Closure
     {
-        return static function (string $sql, array $params = []) use ($dailyStatuses, $dueRetryCounts, $futureQueuedCounts, $knownDayCounts): mixed {
+        return static function (string $sql, array $params = []) use ($dailyStatuses, $dueRetryCounts, $futureQueuedCounts, $knownDayCounts, $emptyCounts): mixed {
             $key = ($params['companyId'] ?? '').':'.($params['connectionId'] ?? '');
             $rangeKey = $key.':'.($params['fromDate'] ?? '').':'.($params['toDate'] ?? '');
             if (str_contains($sql, 'COUNT(DISTINCT business_date)')) {
@@ -382,6 +424,9 @@ final class WbFinancialReportsOrchestrateCommandTest extends TestCase
             }
             if (str_contains($sql, "status = 'queued'") && str_contains($sql, 'next_retry_at > NOW()')) {
                 return $futureQueuedCounts[$rangeKey] ?? $futureQueuedCounts[$key] ?? 0;
+            }
+            if (str_contains($sql, "status = 'empty'")) {
+                return $emptyCounts[$rangeKey] ?? $emptyCounts[$key] ?? 0;
             }
             if (str_contains($sql, "status IN ('queued', 'failed')")) {
                 return $dueRetryCounts[$rangeKey] ?? $dueRetryCounts[$key] ?? 0;


### PR DESCRIPTION
## What changed

- Adds recovery planning for current-month WB finance days stuck in `empty` with zero records.
- Schedules those days through existing `refresh_14d` with `forceRefresh=true`, limited to rows with `attempts < 5`.
- Rotates empty-day recovery by oldest `updated_at` so the hourly orchestrator does not burn all retries on one business date before reaching the others.
- Keeps daily, due retry, and missing recovery ahead of empty-day refresh.
- Shows `recovery_empty_count` in the orchestrator output.
- Updates the Marketplace WB status block to show the current month and clarifies that the lower history table is raw documents.

## Why

WB can return an empty response for a day that later has report rows. The legacy handler stored that as terminal `empty`, and normal `daily` / `missing` planning would not reload it. This left sales days visible as zero-record loaded days.

## Validation

- `php -l` on changed PHP files
- `php bin/phpunit tests/Unit/Marketplace/Application/Service/WbFinancialReportSyncPlannerTest.php tests/Unit/Marketplace/Command/WbFinancialReportsOrchestrateCommandTest.php`
- `make site-test-unit`
- `php bin/console lint:twig templates/marketplace/index.html.twig --env=test`

`make site-test-unit` passed with the existing 1 warning / 1 deprecation.