### PR TITLE
[codex] Refresh WB finance cron over fourteen days

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -2157,8 +2157,7 @@ paths:
 | `app:marketplace:daily-sync` | `04:30 daily` | Диспатч загрузки данных по активным подключениям |
 | `app:inventory:ozon-daily-sync` | `04:05 daily` | Диспатч загрузки Ozon Inventory snapshot по активным Ozon SELLER подключениям |
 | `app:marketplace:wb-financial-reports:sync --mode=daily` | `03:10 daily` | Ежедневное планирование WB financial sync за рабочий день (новая date-based команда) |
-| `app:marketplace:wb-financial-reports:sync --mode=refresh14` | `04:20 daily` | Планирование пересинхронизации последних 14 дней WB financial reports |
-| `app:marketplace:wb-financial-reports:sync --mode=missing --max-days=10` | `05:30 daily` | Планирование дозагрузки пропущенных дней (до 10 дней на подключение) |
+| `app:marketplace:wb-financial-reports:orchestrate --refresh-days-back=14` | `20 * * * *` | Hourly safe planner: current-month daily/retry/missing/empty recovery, then rolling refresh of the last 14 days; max one task per connection per run |
 | `app:ingestion:ozon-performance:daily-load --window=month-to-date` | `07:25 daily` | Планирование Ozon Performance ingestion с начала месяца до вчерашнего дня; HTTP-загрузка выполняется `ingest_fetch` worker'ом |
 
 **Правила для новых cron-команд:**

--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -17,10 +17,11 @@
 # Временно отключено: восстановление пропущенных дней
 #10 * * * * cd /app && php bin/console app:marketplace:wb-financial-reports:sync --mode=missing --max-days=1 --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
 
-# Оркестрация WB financial reports: каждый час проверяет последние 7 дней.
-# Команда сама учитывает cooldown/LockableTrait и ставит не больше одной задачи на подключение;
-# при отсутствии sync-status за день планирует загрузку как recent missing.
-20 * * * * cd /app && php bin/console app:marketplace:wb-financial-reports:orchestrate --retry-window-days=7 --refresh-days-back=2 --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
+# Оркестрация WB financial reports: каждый час восстанавливает текущий месяц
+# (daily/retry/missing/empty), затем переобновляет последние 14 дней для
+# задних правок WB. Команда учитывает cooldown/LockableTrait и ставит не
+# больше одной задачи на подключение за запуск.
+20 * * * * cd /app && php bin/console app:marketplace:wb-financial-reports:orchestrate --refresh-days-back=14 --no-interaction --quiet >> /proc/1/fd/1 2>> /proc/1/fd/2
 
 # Ночная синхронизация отчётов Ozon по реализации.
 0 4 * * * php bin/console app:marketplace:ozon-daily-sync --no-interaction


### PR DESCRIPTION
## What changed

- Updates the active WB finance orchestrator cron to use `--refresh-days-back=14`.
- Removes deprecated `--retry-window-days=7` from the cron invocation.
- Updates the architecture cron table to document the active hourly orchestrator instead of the disabled legacy `refresh14` / `missing` entries.

## Why

WB can adjust financial report rows retroactively. The orchestrator already handles current-month daily/retry/missing/empty recovery safely and limits dispatching to one task per connection per run. Expanding the rolling refresh window to 14 days lets the scheduler pick up WB retroactive changes without manual operator runs.

## Validation

- `docker compose -f docker-compose.prod.yml run --rm -T --entrypoint supercronic scheduler -test /etc/crontabs/app.cron`
- `git diff --check -- docker/cron/app.cron ARCHITECTURE.md`

Note: the supercronic check passed with `crontab is valid`.