### PR TITLE
[codex] Rename unit extended stock header

### DIFF
--- a/site/assets/react/_legacy/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
+++ b/site/assets/react/_legacy/marketplace-analytics/unit-extended/UnitExtendedTable.tsx
@@ -136,7 +136,7 @@ function resolveScrollContainer(wrapper: HTMLDivElement | null): HTMLElement | n
     return wrapper;
 }
 
-const HEADERS: { field: SortField; label: string; align?: string; tooltip?: string }[] = [
+const HEADERS: { field: SortField; label: React.ReactNode; align?: string; tooltip?: string }[] = [
     { field: 'sku', label: 'SKU' },
     { field: 'title', label: 'Наименование' },
     { field: 'sellerArticle', label: 'Артикул' },
@@ -146,7 +146,7 @@ const HEADERS: { field: SortField; label: string; align?: string; tooltip?: stri
     { field: 'costPriceTotal', label: 'Себестоимость', align: 'text-end' },
     { field: 'costPriceUnit', label: 'Себест. ед.', align: 'text-end' },
     { field: 'stockQty', label: 'Ост. шт.', align: 'text-end' },
-    { field: 'stockCapitalRub', label: 'Кап. р.', align: 'text-end' },
+    { field: 'stockCapitalRub', label: <>Остаток на МП<br />FBO/FBS/RFBS</>, align: 'text-end' },
     { field: 'commission', label: 'Комиссия', align: 'text-end' },
     { field: 'adSpend', label: 'РР', align: 'text-end', tooltip: 'Рекламные расходы' },
     { field: 'drrPercent', label: 'ДРР(п) %', align: 'text-end', tooltip: 'Доля рекламных расходов от продаж' },

--- a/site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporter.php
+++ b/site/src/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporter.php
@@ -39,7 +39,7 @@ final readonly class UnitExtendedXlsxExporter
         ['label' => 'Себестоимость',   'field' => 'costPriceTotal', 'type' => 'money'],
         ['label' => 'Себест. ед.',     'field' => 'costPriceUnit',  'type' => 'money'],
         ['label' => 'Ост. шт.',        'field' => 'stockQty',      'type' => 'number'],
-        ['label' => 'Кап. р.',         'field' => 'stockCapitalRub','type' => 'money'],
+        ['label' => 'Остаток на МП FBO/FBS/RFBS', 'field' => 'stockCapitalRub', 'type' => 'money'],
         ['label' => 'Комиссия',        'field' => 'commission',     'type' => 'money'],
         ['label' => 'РР',              'field' => 'adSpend',        'type' => 'money'],
         ['label' => 'ДРР(п) %',        'field' => 'drrPercent',     'type' => 'percent'],

--- a/site/tests/Unit/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporterTest.php
+++ b/site/tests/Unit/MarketplaceAnalytics/Infrastructure/Export/UnitExtendedXlsxExporterTest.php
@@ -154,7 +154,7 @@ final class UnitExtendedXlsxExporterTest extends TestCase
         self::assertContains('ROI %', $header);
         $costUnitColumnIndex = array_search('Себест. ед.', $header, true);
         $stockQtyColumnIndex = array_search('Ост. шт.', $header, true);
-        $stockCapitalColumnIndex = array_search('Кап. р.', $header, true);
+        $stockCapitalColumnIndex = array_search('Остаток на МП FBO/FBS/RFBS', $header, true);
         self::assertSame($costUnitColumnIndex + 1, $stockQtyColumnIndex);
         self::assertSame($stockQtyColumnIndex + 1, $stockCapitalColumnIndex);
 


### PR DESCRIPTION
## Summary
- Rename the unit-extended stock capital column header in the React table
- Use the full header in the XLSX export
- Update the XLSX exporter unit test expectation

## Checks
- docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter UnitExtendedXlsxExporterTest
- docker compose run --rm site-frontend npm run build

## Scope
Only the unit-extended UI/XLSX label change is included. Existing unrelated local docs changes are not part of this PR.