### PR TITLE
[codex] Configure cashflow category flow kinds

### DIFF
--- a/site/src/Cash/Controller/Transaction/CashflowCategoryController.php
+++ b/site/src/Cash/Controller/Transaction/CashflowCategoryController.php
@@ -10,9 +10,9 @@ use App\Shared\Service\ActiveCompanyService;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -46,7 +46,7 @@ class CashflowCategoryController extends AbstractController
             $items,
         );
 
-        $response = new Response(json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT | JSON_THROW_ON_ERROR));
+        $response = new Response(json_encode($payload, \JSON_UNESCAPED_UNICODE | \JSON_PRETTY_PRINT | \JSON_THROW_ON_ERROR));
         $response->headers->set('Content-Type', 'application/json; charset=utf-8');
         $response->headers->set(
             'Content-Disposition',
@@ -76,6 +76,7 @@ class CashflowCategoryController extends AbstractController
         $form = $this->createForm(CashflowCategoryType::class, $article, [
             'parents' => $parents,
             'plCategories' => $plCategories,
+            'allow_flow_kind_edit' => $article->isRoot(),
         ]);
         $form->handleRequest($request);
 
@@ -83,6 +84,7 @@ class CashflowCategoryController extends AbstractController
             if ($article->getParent() && $article->getParent()->getLevel() >= 5) {
                 $this->addFlash('danger', 'Максимальная вложенность — 5 уровней');
             } else {
+                $article->syncFlowKindSubtree();
                 $em->persist($article);
                 $em->flush();
 
@@ -115,6 +117,7 @@ class CashflowCategoryController extends AbstractController
         $form = $this->createForm(CashflowCategoryType::class, $article, [
             'parents' => $parents,
             'plCategories' => $plCategories,
+            'allow_flow_kind_edit' => $article->isRoot(),
         ]);
         $form->handleRequest($request);
 
@@ -122,6 +125,7 @@ class CashflowCategoryController extends AbstractController
             if ($article->getParent() && $article->getParent()->getLevel() >= 5) {
                 $this->addFlash('danger', 'Максимальная вложенность — 5 уровней');
             } else {
+                $article->syncFlowKindSubtree();
                 $em->flush();
 
                 return $this->redirectToRoute('cashflow_category_index');

--- a/site/src/Cash/Entity/Transaction/CashflowCategory.php
+++ b/site/src/Cash/Entity/Transaction/CashflowCategory.php
@@ -2,12 +2,12 @@
 
 namespace App\Cash\Entity\Transaction;
 
+use App\Cash\Enum\PaymentPlan\PaymentPlanType;
 use App\Cash\Enum\Transaction\CashflowCategoryStatus;
 use App\Cash\Enum\Transaction\CashflowFlowKind;
 use App\Cash\Repository\Transaction\CashflowCategoryRepository;
 use App\Company\Entity\Company;
 use App\Finance\Entity\PLCategory;
-use App\Cash\Enum\PaymentPlan\PaymentPlanType;
 use Doctrine\Common\Collections\ArrayCollection;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
@@ -134,9 +134,23 @@ class CashflowCategory
 
     public function setParent(?self $parent): self
     {
+        if ($this->parent === $parent) {
+            return $this;
+        }
+
+        $this->parent?->children->removeElement($this);
         $this->parent = $parent;
 
+        if (null !== $parent && !$parent->children->contains($this)) {
+            $parent->children->add($this);
+        }
+
         return $this;
+    }
+
+    public function isRoot(): bool
+    {
+        return null === $this->parent;
     }
 
     public function getChildren(): Collection
@@ -212,6 +226,31 @@ class CashflowCategory
     public function setFlowKind(CashflowFlowKind $kind): self
     {
         $this->flowKind = $kind;
+
+        return $this;
+    }
+
+    public function getEffectiveFlowKind(): CashflowFlowKind
+    {
+        return $this->parent?->getEffectiveFlowKind() ?? $this->flowKind;
+    }
+
+    public function syncFlowKindWithParent(): self
+    {
+        if (null !== $this->parent) {
+            $this->flowKind = $this->parent->getEffectiveFlowKind();
+        }
+
+        return $this;
+    }
+
+    public function syncFlowKindSubtree(): self
+    {
+        $this->syncFlowKindWithParent();
+
+        foreach ($this->children as $child) {
+            $child->syncFlowKindSubtree();
+        }
 
         return $this;
     }

--- a/site/src/Cash/Enum/Transaction/CashflowFlowKind.php
+++ b/site/src/Cash/Enum/Transaction/CashflowFlowKind.php
@@ -7,4 +7,15 @@ enum CashflowFlowKind: string
     case OPERATING = 'OPERATING';
     case INVESTING = 'INVESTING';
     case FINANCING = 'FINANCING';
+    case TECHNICAL = 'TECHNICAL';
+
+    public function label(): string
+    {
+        return match ($this) {
+            self::OPERATING => 'Операционная деятельность',
+            self::INVESTING => 'Инвестиционная деятельность',
+            self::FINANCING => 'Финансовая деятельность',
+            self::TECHNICAL => 'Технические операции',
+        };
+    }
 }

--- a/site/src/Cash/Form/Transaction/CashflowCategoryType.php
+++ b/site/src/Cash/Form/Transaction/CashflowCategoryType.php
@@ -32,16 +32,22 @@ class CashflowCategoryType extends AbstractType
             ->add('status', EnumType::class, [
                 'class' => CashflowCategoryStatus::class,
                 'label' => 'Статус',
-            ])
-            ->add('flowKind', ChoiceType::class, [
-                'label' => 'Вид потока',
+            ]);
+
+        if ($options['allow_flow_kind_edit']) {
+            $builder->add('flowKind', ChoiceType::class, [
+                'label' => 'Вид деятельности',
                 'choices' => [
-                    CashflowFlowKind::OPERATING->value => CashflowFlowKind::OPERATING,
-                    CashflowFlowKind::INVESTING->value => CashflowFlowKind::INVESTING,
-                    CashflowFlowKind::FINANCING->value => CashflowFlowKind::FINANCING,
+                    CashflowFlowKind::OPERATING->label() => CashflowFlowKind::OPERATING,
+                    CashflowFlowKind::INVESTING->label() => CashflowFlowKind::INVESTING,
+                    CashflowFlowKind::FINANCING->label() => CashflowFlowKind::FINANCING,
+                    CashflowFlowKind::TECHNICAL->label() => CashflowFlowKind::TECHNICAL,
                 ],
                 'choice_value' => static fn (?CashflowFlowKind $flowKind) => $flowKind?->value,
-            ])
+            ]);
+        }
+
+        $builder
             ->add('isSystem', CheckboxType::class, [
                 'label' => 'Системная категория',
                 'required' => false,
@@ -70,7 +76,7 @@ class CashflowCategoryType extends AbstractType
             ->add('parent', EntityType::class, [
                 'class' => CashflowCategory::class,
                 'choices' => $options['parents'],
-                'choice_label' => function (CashflowCategory $item) {
+                'choice_label' => static function (CashflowCategory $item) {
                     return str_repeat('—', $item->getLevel() - 1).' '.$item->getName();
                 },
                 'required' => false,
@@ -79,7 +85,7 @@ class CashflowCategoryType extends AbstractType
             ->add('plCategory', EntityType::class, [
                 'class' => PLCategory::class,
                 'choices' => $options['plCategories'],
-                'choice_label' => function (PLCategory $item) {
+                'choice_label' => static function (PLCategory $item) {
                     return str_repeat('—', $item->getLevel() - 1).' '.$item->getName();
                 },
                 'required' => false,
@@ -94,6 +100,7 @@ class CashflowCategoryType extends AbstractType
             'data_class' => CashflowCategory::class,
             'parents' => [],
             'plCategories' => [],
+            'allow_flow_kind_edit' => false,
         ]);
     }
 }

--- a/site/templates/cashflow_category/edit.html.twig
+++ b/site/templates/cashflow_category/edit.html.twig
@@ -26,9 +26,11 @@
                 <div class="mt-3">
                     <h3 class="h5 mb-3">Метаданные для отчётов</h3>
                     <div class="row">
-                        <div class="col-md-4">
-                            {{ form_row(form.flowKind, { help: 'для отчёта Денежный поток' }) }}
-                        </div>
+                        {% if form.flowKind is defined %}
+                            <div class="col-md-4">
+                                {{ form_row(form.flowKind, { help: 'только для категорий верхнего уровня' }) }}
+                            </div>
+                        {% endif %}
                         <div class="col-md-4">
                             {{ form_row(form.isSystem) }}
                         </div>

--- a/site/templates/cashflow_category/new.html.twig
+++ b/site/templates/cashflow_category/new.html.twig
@@ -26,9 +26,11 @@
                 <div class="mt-3">
                     <h3 class="h5 mb-3">Метаданные для отчётов</h3>
                     <div class="row">
-                        <div class="col-md-4">
-                            {{ form_row(form.flowKind, { help: 'для отчёта Денежный поток' }) }}
-                        </div>
+                        {% if form.flowKind is defined %}
+                            <div class="col-md-4">
+                                {{ form_row(form.flowKind, { help: 'только для категорий верхнего уровня' }) }}
+                            </div>
+                        {% endif %}
                         <div class="col-md-4">
                             {{ form_row(form.isSystem) }}
                         </div>

--- a/site/tests/Unit/Cash/Entity/CashflowCategoryTest.php
+++ b/site/tests/Unit/Cash/Entity/CashflowCategoryTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Cash\Entity;
+
+use App\Cash\Entity\Transaction\CashflowCategory;
+use App\Cash\Enum\Transaction\CashflowFlowKind;
+use App\Tests\Builders\Company\CompanyBuilder;
+use PHPUnit\Framework\TestCase;
+
+final class CashflowCategoryTest extends TestCase
+{
+    public function testTechnicalFlowKindHasLabel(): void
+    {
+        self::assertSame('Технические операции', CashflowFlowKind::TECHNICAL->label());
+    }
+
+    public function testRootCategoryUsesOwnEffectiveFlowKind(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+        $category = new CashflowCategory('11111111-1111-4111-8111-111111111111', $company);
+        $category->setFlowKind(CashflowFlowKind::FINANCING);
+
+        self::assertTrue($category->isRoot());
+        self::assertSame(CashflowFlowKind::FINANCING, $category->getEffectiveFlowKind());
+    }
+
+    public function testChildCategoryInheritsEffectiveFlowKindFromRoot(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+
+        $root = new CashflowCategory('11111111-1111-4111-8111-111111111111', $company);
+        $root->setFlowKind(CashflowFlowKind::INVESTING);
+
+        $child = new CashflowCategory('22222222-2222-4222-8222-222222222222', $company);
+        $child->setParent($root);
+        $child->setFlowKind(CashflowFlowKind::OPERATING);
+
+        self::assertFalse($child->isRoot());
+        self::assertSame(CashflowFlowKind::INVESTING, $child->getEffectiveFlowKind());
+    }
+
+    public function testChildCategorySyncsStoredFlowKindFromParent(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+
+        $root = new CashflowCategory('11111111-1111-4111-8111-111111111111', $company);
+        $root->setFlowKind(CashflowFlowKind::TECHNICAL);
+
+        $child = new CashflowCategory('22222222-2222-4222-8222-222222222222', $company);
+        $child->setParent($root);
+        $child->setFlowKind(CashflowFlowKind::OPERATING);
+
+        $child->syncFlowKindWithParent();
+
+        self::assertSame(CashflowFlowKind::TECHNICAL, $child->getFlowKind());
+    }
+
+    public function testRootCategorySyncsStoredFlowKindThroughDescendants(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+
+        $root = new CashflowCategory('11111111-1111-4111-8111-111111111111', $company);
+        $root->setFlowKind(CashflowFlowKind::TECHNICAL);
+
+        $child = new CashflowCategory('22222222-2222-4222-8222-222222222222', $company);
+        $child->setParent($root);
+        $child->setFlowKind(CashflowFlowKind::OPERATING);
+
+        $grandchild = new CashflowCategory('33333333-3333-4333-8333-333333333333', $company);
+        $grandchild->setParent($child);
+        $grandchild->setFlowKind(CashflowFlowKind::FINANCING);
+
+        $root->syncFlowKindSubtree();
+
+        self::assertSame(CashflowFlowKind::TECHNICAL, $root->getFlowKind());
+        self::assertSame(CashflowFlowKind::TECHNICAL, $child->getFlowKind());
+        self::assertSame(CashflowFlowKind::TECHNICAL, $grandchild->getFlowKind());
+    }
+
+    public function testMovedSubtreeSyncsStoredFlowKindFromNewRoot(): void
+    {
+        $company = CompanyBuilder::aCompany()->build();
+
+        $oldRoot = new CashflowCategory('11111111-1111-4111-8111-111111111111', $company);
+        $oldRoot->setFlowKind(CashflowFlowKind::OPERATING);
+
+        $newRoot = new CashflowCategory('22222222-2222-4222-8222-222222222222', $company);
+        $newRoot->setFlowKind(CashflowFlowKind::FINANCING);
+
+        $child = new CashflowCategory('33333333-3333-4333-8333-333333333333', $company);
+        $child->setParent($oldRoot);
+        $child->setFlowKind(CashflowFlowKind::OPERATING);
+
+        $grandchild = new CashflowCategory('44444444-4444-4444-8444-444444444444', $company);
+        $grandchild->setParent($child);
+        $grandchild->setFlowKind(CashflowFlowKind::OPERATING);
+
+        $child->setParent($newRoot);
+        $child->syncFlowKindSubtree();
+
+        self::assertSame(CashflowFlowKind::FINANCING, $child->getFlowKind());
+        self::assertSame(CashflowFlowKind::FINANCING, $grandchild->getFlowKind());
+    }
+}


### PR DESCRIPTION
## Summary
- restrict Cashflow flow-kind editing to root categories
- add TECHNICAL flow kind with Russian labels
- sync stored flowKind through descendants when a category/root is saved or moved
- add unit coverage for inheritance, cascade sync, and moved subtrees

## Checks
- docker compose run --rm site-php-cli php bin/phpunit --testsuite unit --filter CashflowCategoryTest --display-warnings --display-deprecations
- docker compose run --rm site-php-cli composer test:unit
- docker compose run --rm site-php-cli php bin/console lint:twig templates/cashflow_category --env=test
- docker compose run --rm site-php-cli ./vendor/bin/php-cs-fixer fix --dry-run --diff --config=.php-cs-fixer.php --cache-file=var/cache/.php-cs-fixer.cashflow-kind.cache src/Cash/Enum/Transaction/CashflowFlowKind.php src/Cash/Entity/Transaction/CashflowCategory.php src/Cash/Form/Transaction/CashflowCategoryType.php src/Cash/Controller/Transaction/CashflowCategoryController.php tests/Unit/Cash/Entity/CashflowCategoryTest.php
- git diff --check

Note: full unit suite still reports one existing warning in StorageServiceTest and one existing deprecation in XlsxReaderServiceTest; both are outside this change.