### PR TITLE
feat(storage): PR 1 — расширить ObjectStorageInterface (readStream/delete) + TemporaryLocalFile

### DIFF
--- a/docs/tasks/s3-migration/plan.md
+++ b/docs/tasks/s3-migration/plan.md
@@ -1,0 +1,149 @@
+# S3 Migration — Plan (Phase 0)
+
+> Цель: увести файловое хранилище с локального docker-тома на S3 (timeweb),
+> чтобы приложение стало stateless и могло разъехаться на несколько машин.
+> Способ: **branch-by-abstraction** — сначала весь код на единый
+> `ObjectStorageInterface` под драйвером `local` (поведение не меняется),
+> и только в самом конце — флип на S3.
+
+## Контекст / факты (аудит выполнен)
+
+- Инфраструктура уже написана: `league/flysystem` + `flysystem-aws-s3-v3`,
+  `ObjectStorageInterface`, реализации `LocalObjectStorage` / `FlysystemS3ObjectStorage`,
+  `ObjectStorageFactory`. Драйвер по умолчанию — `local` (S3 подключён, но выключен).
+- Хранилище **глобальное, один драйвер, один бакет** (env `APP_OBJECT_STORAGE_DRIVER`).
+  Не пер-компанийное. Суффикс `_default` в services.yaml — это Symfony env-fallback.
+- Env-префикс: `APP_OBJECT_STORAGE_*`
+  (`DRIVER`, `S3_BUCKET`, `S3_REGION`, `S3_ENDPOINT`, `S3_ACCESS_KEY`,
+  `S3_SECRET_KEY`, `S3_PATH_STYLE_ENDPOINT`).
+- Объём данных на дисках — **крошечный**: `site_company_storage` 6 файлов / 32 КБ,
+  `site_storage` 8 файлов / 72 МБ. Тяжёлые `raw_documents` (600+ МБ) лежат в БД (bytea),
+  на S3 не едут.
+- Всё уже под корнем `var/storage/` → при S3-sync ключи ложатся 1:1, физического
+  перемещения на этапе рефактора нет.
+
+## Ключевой принцип (behavior-preserving рефактор)
+
+> **Ключ, передаваемый в `ObjectStorageInterface`, обязан точно равняться
+> относительному пути, уже сохранённому в БД.**
+
+- Корень `LocalObjectStorage` = `var/storage` (текущий `app.storage_root`).
+- Пути в БД не переписываем, файлы не двигаем, миграций БД нет.
+- Единая схема ключей — только для **новых** записей, старые исторические
+  пути остаются как есть (для S3 ключ есть ключ).
+
+## Текущее состояние абстракции (проблема)
+
+`ObjectStorageInterface` = правильная точка входа, но **~18 мест инжектят
+`StorageService` напрямую** в обход интерфейса и намертво привязаны к
+локальному диску (`getAbsolutePath()` + raw `file_put_contents`/`fopen`).
+Плюс 2 потока (тип C) пишут на диск вообще мимо `StorageService`.
+
+Цель порядка: `ObjectStorageInterface` — единственный публичный сервис,
+`StorageService` — приватная деталь `LocalObjectStorage`.
+
+## Классификация точек ввода-вывода
+
+| Тип | Что | Где | Как чинится |
+|---|---|---|---|
+| **A** | Отдача файла в HTTP-ответ | `AdScheduledBatchDownloadController`, `AdRawDocumentDownloadController`, `Api/Admin/DownloadBronzeController`, `Api/DebugDownloadRawDocumentController` | `getAbsolutePath()`+`BinaryFileResponse` → `readStream()`+`StreamedResponse` |
+| **B** | Путь скармливается парсеру (нужен реальный файл) | `ImportProductsFromXlsAction` (PhpSpreadsheet), `LoadMutualSettlementAction`, `Reconciliation/OzonReportParserFacade`, `ImportInventoryCostPriceHandler`, `ExtractBatchesToRawDocumentsAction` (ZipArchive), `Api/DebugReparseMutualSettlementController` | Хелпер `TemporaryLocalFile::with()` — скачать в `/tmp`, отдать парсеру, удалить |
+| **C** | Прямая запись на диск в обход всего (cross-tier: web пишет, worker читает по пути) | `Cash/Controller/Import/CashFileImportController` + `Cash/Service/Import/File/*` (`var/storage/cash-file-imports`), `Telegram/Controller/TelegramWebhookController` (`var/storage/telegram-imports`) | web пишет через `write()`, worker читает через `TemporaryLocalFile` |
+
+**Не трогаем:** `tempnam(sys_get_temp_dir())` в Ozon-клиентах (это `/tmp`, эфемерно),
+`php://memory` / `php://output` (потоки, не диск), `MakeModuleCommand` (dev-кодоген).
+
+## Проектные решения (best practices, утверждены)
+
+- **Интерфейс:** добавить `readStream()` и `delete()`. `withLocalCopy` в интерфейс
+  НЕ добавлять — отдельный сервис `TemporaryLocalFile`, зависит от интерфейса.
+- **Схема ключей (новые записи):** `{module}/{companyId}/{ulid}.{ext}`.
+  Полный ключ хранить в БД. Дату-партицию (`/{yyyy}/{mm}/`) добавлять только там,
+  где будет lifecycle-истечение (raw-импорты).
+- **Провайдер:** прод — один бакет timeweb. dev/test — драйвер `local` (без креденшелов).
+  MinIO в compose — опционально, только для отладки S3-пути.
+- **Шифрование:** сейчас — бакет приватный + TLS-only. SSE-S3 — целевой механизм,
+  включается позже флагом бакета (без кода). App-level шифрование не дублировать.
+- **Бэкап/retention:** versioning бакета (= бэкап) + одно lifecycle-правило
+  (удалять неактуальные версии через 30 дней). Отдельный пайплайн не строим.
+- **Cutover без fallback-декоратора** (данных 72 МБ — оверинжиниринг не нужен):
+  пауза загрузок → `s3 sync` (копия) → флип env → сверка → грейс 2 недели → удалить local.
+- **Грейс/рубильник:** local-том остаётся как холодный бэкап; авто-сверка паритета
+  (пути из БД ↔ существование в S3); удаление local — решение Владельца после
+  зелёной сверки + 2 недель без ошибок «файл не найден» в GlitchTip.
+
+## Итерации (PR-per-stage)
+
+Каждый PR: драйвер `local`, поведение байт-в-байт, свои тесты, откатывается
+независимо. Бэкенд меняет только PR 8.
+
+### PR 1 — расширить контракт `ObjectStorageInterface` — 🟡 MEDIUM
+- `readStream(string $path)` + `delete(string $path)` в интерфейс.
+- Реализовать в `LocalObjectStorage` и `FlysystemS3ObjectStorage`.
+- Новый сервис `TemporaryLocalFile` (read → tempnam → callable → unlink).
+- Additive: вызовов ещё нет, рантайм не меняется.
+- Тесты: unit на `TemporaryLocalFile` (создаёт/удаляет tmp, пробрасывает исключение),
+  unit на `Local.readStream/delete`.
+
+### PR 2 — простые store/read сайты → интерфейс — 🟡 MEDIUM
+- Catalog (`ProductImportController` ×2, `ImportProductsFromXlsAction` — часть store),
+  прочие места, где только `storeUploadedFile`/`storeBytes`/`exists`.
+- Пути сохраняем как есть.
+- Тесты: functional на импорт продукта (файл сохраняется и читается по тому же пути).
+
+### PR 3 — тип C: cash-импорт → интерфейс — 🟡 MEDIUM
+- `CashFileImportController` пишет через `write()`, ключ = прежний относительный путь.
+- `CashFileImportService`/`Reader` читают через `TemporaryLocalFile`.
+- **Cross-tier блокер снят** (web ↔ worker больше не через общий диск).
+- Тесты: регрессионный smoke реального импорта (загрузка → парсинг воркером).
+
+### PR 4 — тип C: telegram-импорт → интерфейс — 🟡 MEDIUM
+- `TelegramWebhookController` → `write()`; читатель → `TemporaryLocalFile`.
+- Тесты: приём файла из webhook → обработка воркером.
+
+### PR 5 — тип B: парсеры через `TemporaryLocalFile` — 🟡 MEDIUM
+- `LoadMutualSettlementAction`, `OzonReportParserFacade`, `ImportInventoryCostPriceHandler`,
+  `ExtractBatchesToRawDocumentsAction`, `DebugReparseMutualSettlementController`.
+- Можно разбить на 2 PR: `Marketplace` / `MarketplaceAds`.
+- Тесты: по одному happy-path на каждый парсер (файл читается из хранилища, парсится).
+
+### PR 6 — тип A: download-контроллеры → `readStream()` — 🟢 LOW
+- 4 контроллера: `getAbsolutePath()`+`BinaryFileResponse` → `readStream()`+`StreamedResponse`.
+- Проксирование через приложение сохраняем (авторизация/companyId в контроллере,
+  бакет приватный). Presigned URL не вводим.
+- Тесты: functional на скачивание (200 + корректные байты + проверка companyId).
+
+### PR 7 — спрятать `StorageService` — 🟢 LOW
+- Когда прямых внешних вызовов не осталось: `@internal`, убрать из public DI,
+  оставить видимым только для `LocalObjectStorage`.
+- Тесты: `make stan` (нет внешних импортов `StorageService`).
+
+### PR 8 — инфра + флип на S3 — 🔴 HIGH (STOP перед выполнением)
+1. Бакет timeweb (приватный, TLS-only, versioning вкл., lifecycle 30 дней на
+   неактуальные версии; SSE-S3 подготовлен, но выключен).
+2. `APP_OBJECT_STORAGE_*` в host-env + прокинуть в `x-php-env` и в блок env
+   `scheduler` в `docker-compose.prod.yml` (сейчас переменных там нет).
+3. Пауза загрузок/воркеров (окно секунды) → `aws s3 sync var/storage → s3://bucket` (копия).
+4. Флип `APP_OBJECT_STORAGE_DRIVER=s3` → старт.
+5. Авто-сверка паритета (пути из БД ↔ `exists` в S3) → грейс 2 недели → удалить local.
+- Rollback: вернуть `APP_OBJECT_STORAGE_DRIVER=local` (данные на месте).
+
+## Открытые вопросы к Владельцу (закрыть до PR 8)
+
+1. Значения для timeweb: endpoint, region, path-style (0/1), имя бакета.
+2. Точное окно паузы для cutover (согласовать время).
+3. Кто владелец команды сверки паритета и решения об удалении local.
+
+## Риски
+
+- Тип C (PR 3/4) меняет поток загрузки — обязателен ручной smoke реального импорта.
+- Тип B — парсеры чувствительны к реальному пути; проверить, что `TemporaryLocalFile`
+  корректно чистит `/tmp` при исключении (нет утечки файлов).
+- PR 8 — единственная точка невозврата; local-том держим как откат весь грейс-период.
+
+## Follow-ups (вне scope)
+
+- Разбор, что именно лежит в `site_storage` vs `site_company_storage` (перенесли всё,
+  разбираемся потом — объём мал).
+- Возможный вынос `raw_documents` из БД (bytea) в S3 — отдельная задача.
+- Включение SSE-S3, если потребует комплаенс.

--- a/docs/tasks/s3-migration/stages/stage-1.md
+++ b/docs/tasks/s3-migration/stages/stage-1.md
@@ -1,0 +1,45 @@
+## Stage 1 (PR 1): Расширить контракт ObjectStorageInterface — DONE
+
+**Риск:** 🟡 MEDIUM
+**Следующее действие:** continue autonomously (PR 2), но сначала PR 1 на ревью/мерж Владельцем
+
+### Что сделано
+- В `ObjectStorageInterface` добавлены `readStream(): resource` и `delete(): void`.
+- Реализованы в `LocalObjectStorage` (через `getAbsolutePath` + `fopen`/`unlink`) и
+  `FlysystemS3ObjectStorage` (через `Filesystem::readStream`/`delete`).
+- `delete()` идемпотентен: удаление отсутствующего объекта — не ошибка (для cleanup).
+- Новый сервис `TemporaryLocalFile::with()` — скачивает объект во временный файл,
+  отдаёт путь в callable, **гарантированно удаляет tmp через `finally`** (в т.ч. при
+  исключении из парсера — защита от утечки `/tmp`).
+- Additive-изменение: новые методы ещё не вызываются, рантайм прод-поведения не меняется.
+
+### Затронутые файлы
+- `src/Shared/Service/Storage/ObjectStorageInterface.php` — modified (2 метода)
+- `src/Shared/Service/Storage/LocalObjectStorage.php` — modified
+- `src/Shared/Service/Storage/FlysystemS3ObjectStorage.php` — modified
+- `src/Shared/Service/Storage/TemporaryLocalFile.php` — new
+- `tests/Unit/Shared/Service/Storage/LocalObjectStorageTest.php` — modified (readStream, delete ×2)
+- `tests/Unit/Shared/Service/Storage/TemporaryLocalFileTest.php` — new
+
+### Self-review
+- [x] Scope compliance — только контракт + хелпер, вызовов не трогал
+- [x] Patterns / naming — `final readonly class`, `declare(strict_types=1)`, интерфейс-порт чистый
+- [x] Forbidden actions — none (нет new Service, нет flush, нет dump/dd)
+- [x] Security — path traversal уже прикрыт в `StorageService::storeBytes`; `delete` идемпотентен
+- [x] Tests green — 7 tests / 20 assertions OK
+- [x] CS-Fixer — чисто (0 из 6 файлов к правке)
+- [x] DI — `lint:container` OK, `TemporaryLocalFile` autowired
+- [N/A] PHPStan — в проекте не установлен (только php-cs-fixer)
+- [x] ARCHITECTURE.md — интерфейс расширен, не новый Facade/Enum; отдельная запись не требуется
+
+### Команды для проверки
+- `docker compose run --rm -T site-php-cli php bin/phpunit --testsuite unit --filter 'LocalObjectStorageTest|TemporaryLocalFileTest'`
+- `docker compose run --rm -T site-php-cli php bin/console lint:container`
+
+### Риски / на что обратить внимание ревьюеру
+- `readStream()` без нативного type-hint (PHP не типизирует `resource`) — тип задан phpdoc `@return resource`.
+- `TemporaryLocalFile` — критичная точка: проверь `finally`-чистку (тест
+  `testTemporaryFileRemovedEvenWhenConsumerThrows` красный, если убрать `@unlink`).
+
+### Открытые вопросы
+- нет

--- a/site/src/Shared/Service/Storage/FlysystemS3ObjectStorage.php
+++ b/site/src/Shared/Service/Storage/FlysystemS3ObjectStorage.php
@@ -68,12 +68,30 @@ final class FlysystemS3ObjectStorage implements ObjectStorageInterface
         }
     }
 
+    public function readStream(string $path)
+    {
+        try {
+            return $this->filesystem->readStream($path);
+        } catch (FilesystemException $exception) {
+            throw new ObjectStorageException(sprintf('Failed to read object "%s".', $path), 0, $exception);
+        }
+    }
+
     public function exists(string $path): bool
     {
         try {
             return $this->filesystem->fileExists($path);
         } catch (FilesystemException $exception) {
             throw new ObjectStorageException(sprintf('Failed to check object "%s".', $path), 0, $exception);
+        }
+    }
+
+    public function delete(string $path): void
+    {
+        try {
+            $this->filesystem->delete($path);
+        } catch (FilesystemException $exception) {
+            throw new ObjectStorageException(sprintf('Failed to delete object "%s".', $path), 0, $exception);
         }
     }
 }

--- a/site/src/Shared/Service/Storage/LocalObjectStorage.php
+++ b/site/src/Shared/Service/Storage/LocalObjectStorage.php
@@ -27,8 +27,26 @@ final readonly class LocalObjectStorage implements ObjectStorageInterface
         return $contents;
     }
 
+    public function readStream(string $path)
+    {
+        $stream = @fopen($this->storageService->getAbsolutePath($path), 'rb');
+        if (false === $stream) {
+            throw new ObjectStorageException(sprintf('Failed to open object "%s" for reading.', $path));
+        }
+
+        return $stream;
+    }
+
     public function exists(string $path): bool
     {
         return is_file($this->storageService->getAbsolutePath($path));
+    }
+
+    public function delete(string $path): void
+    {
+        $absolutePath = $this->storageService->getAbsolutePath($path);
+        if (is_file($absolutePath) && !@unlink($absolutePath)) {
+            throw new ObjectStorageException(sprintf('Failed to delete object "%s".', $path));
+        }
     }
 }

--- a/site/src/Shared/Service/Storage/LocalObjectStorage.php
+++ b/site/src/Shared/Service/Storage/LocalObjectStorage.php
@@ -45,7 +45,10 @@ final readonly class LocalObjectStorage implements ObjectStorageInterface
     public function delete(string $path): void
     {
         $absolutePath = $this->storageService->getAbsolutePath($path);
-        if (is_file($absolutePath) && !@unlink($absolutePath)) {
+        // Идемпотентность: бросаем только если файл всё ещё на месте после
+        // неудачного unlink. Гонка (кто-то удалил между is_file и unlink) —
+        // не ошибка, итог тот же: файла нет.
+        if (is_file($absolutePath) && !@unlink($absolutePath) && is_file($absolutePath)) {
             throw new ObjectStorageException(sprintf('Failed to delete object "%s".', $path));
         }
     }

--- a/site/src/Shared/Service/Storage/ObjectStorageInterface.php
+++ b/site/src/Shared/Service/Storage/ObjectStorageInterface.php
@@ -10,5 +10,17 @@ interface ObjectStorageInterface
 
     public function read(string $path): string;
 
+    /**
+     * Открыть объект на чтение потоком (для больших файлов и стриминга в HTTP-ответ).
+     *
+     * @return resource
+     */
+    public function readStream(string $path);
+
     public function exists(string $path): bool;
+
+    /**
+     * Удалить объект. Идемпотентно: удаление отсутствующего объекта — не ошибка.
+     */
+    public function delete(string $path): void;
 }

--- a/site/src/Shared/Service/Storage/TemporaryLocalFile.php
+++ b/site/src/Shared/Service/Storage/TemporaryLocalFile.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Service\Storage;
+
+/**
+ * Скачивает объект из хранилища во временный локальный файл, отдаёт его путь
+ * в $consumer и гарантированно удаляет файл после — даже если $consumer бросил.
+ *
+ * Нужно там, где сторонним парсерам (PhpSpreadsheet, ZipArchive, fgetcsv)
+ * требуется реальный путь на диске, а не поток — им нельзя передать "s3://".
+ */
+final readonly class TemporaryLocalFile
+{
+    public function __construct(private ObjectStorageInterface $storage)
+    {
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable(string $localPath): T $consumer
+     *
+     * @return T
+     */
+    public function with(string $path, callable $consumer): mixed
+    {
+        $tmpPath = tempnam(sys_get_temp_dir(), 'objstore-');
+        if (false === $tmpPath) {
+            throw new ObjectStorageException('Failed to allocate a temporary file.');
+        }
+
+        try {
+            $source = $this->storage->readStream($path);
+            $target = @fopen($tmpPath, 'wb');
+            if (false === $target) {
+                throw new ObjectStorageException(sprintf('Failed to open temporary file for object "%s".', $path));
+            }
+
+            try {
+                if (false === stream_copy_to_stream($source, $target)) {
+                    throw new ObjectStorageException(sprintf('Failed to buffer object "%s" to a temporary file.', $path));
+                }
+            } finally {
+                fclose($target);
+                if (is_resource($source)) {
+                    fclose($source);
+                }
+            }
+
+            return $consumer($tmpPath);
+        } finally {
+            @unlink($tmpPath);
+        }
+    }
+}

--- a/site/tests/Unit/Shared/Service/Storage/LocalObjectStorageTest.php
+++ b/site/tests/Unit/Shared/Service/Storage/LocalObjectStorageTest.php
@@ -34,4 +34,50 @@ final class LocalObjectStorageTest extends TestCase
         self::assertSame('company/source/file.ndjson.gz', $stored->path);
         self::assertSame(strlen('payload-bytes'), $stored->byteSize);
     }
+
+    public function testReadStreamOpensAbsolutePath(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'los-');
+        self::assertIsString($tmp);
+        file_put_contents($tmp, 'hello-bytes');
+
+        /** @var StorageService&MockObject $storageService */
+        $storageService = $this->createMock(StorageService::class);
+        $storageService->method('getAbsolutePath')->with('a/b.txt')->willReturn($tmp);
+
+        $stream = (new LocalObjectStorage($storageService))->readStream('a/b.txt');
+
+        self::assertIsResource($stream);
+        self::assertSame('hello-bytes', stream_get_contents($stream));
+        fclose($stream);
+        @unlink($tmp);
+    }
+
+    public function testDeleteRemovesFile(): void
+    {
+        $tmp = tempnam(sys_get_temp_dir(), 'los-');
+        self::assertIsString($tmp);
+        file_put_contents($tmp, 'x');
+
+        /** @var StorageService&MockObject $storageService */
+        $storageService = $this->createMock(StorageService::class);
+        $storageService->method('getAbsolutePath')->willReturn($tmp);
+
+        (new LocalObjectStorage($storageService))->delete('a/b.txt');
+
+        self::assertFileDoesNotExist($tmp);
+    }
+
+    public function testDeleteIsIdempotentForMissingFile(): void
+    {
+        $missing = sprintf('%s/no-such-%s', sys_get_temp_dir(), bin2hex(random_bytes(6)));
+
+        /** @var StorageService&MockObject $storageService */
+        $storageService = $this->createMock(StorageService::class);
+        $storageService->method('getAbsolutePath')->willReturn($missing);
+
+        (new LocalObjectStorage($storageService))->delete('missing');
+
+        $this->addToAssertionCount(1);
+    }
 }

--- a/site/tests/Unit/Shared/Service/Storage/TemporaryLocalFileTest.php
+++ b/site/tests/Unit/Shared/Service/Storage/TemporaryLocalFileTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Service\Storage;
+
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Shared\Service\Storage\TemporaryLocalFile;
+use PHPUnit\Framework\TestCase;
+
+final class TemporaryLocalFileTest extends TestCase
+{
+    public function testConsumerReceivesLocalPathWithObjectContents(): void
+    {
+        $temporaryLocalFile = new TemporaryLocalFile($this->storageReturning('spreadsheet-bytes'));
+
+        $seenContents = null;
+        $result = $temporaryLocalFile->with('imports/company/x.xlsx', function (string $localPath) use (&$seenContents): string {
+            self::assertFileExists($localPath);
+            $seenContents = file_get_contents($localPath);
+
+            return 'parsed';
+        });
+
+        self::assertSame('spreadsheet-bytes', $seenContents);
+        self::assertSame('parsed', $result);
+    }
+
+    public function testTemporaryFileRemovedAfterSuccess(): void
+    {
+        $temporaryLocalFile = new TemporaryLocalFile($this->storageReturning('payload'));
+
+        $capturedPath = null;
+        $temporaryLocalFile->with('a/b', function (string $localPath) use (&$capturedPath): void {
+            $capturedPath = $localPath;
+        });
+
+        self::assertIsString($capturedPath);
+        self::assertFileDoesNotExist($capturedPath);
+    }
+
+    public function testTemporaryFileRemovedEvenWhenConsumerThrows(): void
+    {
+        $temporaryLocalFile = new TemporaryLocalFile($this->storageReturning('payload'));
+
+        $capturedPath = null;
+        try {
+            $temporaryLocalFile->with('a/b', function (string $localPath) use (&$capturedPath): void {
+                $capturedPath = $localPath;
+                throw new \RuntimeException('parser blew up');
+            });
+            self::fail('Expected exception to propagate.');
+        } catch (\RuntimeException $exception) {
+            self::assertSame('parser blew up', $exception->getMessage());
+        }
+
+        self::assertIsString($capturedPath);
+        self::assertFileDoesNotExist($capturedPath);
+    }
+
+    private function storageReturning(string $contents): ObjectStorageInterface
+    {
+        return new class($contents) implements ObjectStorageInterface {
+            public function __construct(private readonly string $contents)
+            {
+            }
+
+            public function write(string $path, string $contents): \App\Shared\Service\Storage\StoredObject
+            {
+                throw new \LogicException('not needed');
+            }
+
+            public function read(string $path): string
+            {
+                return $this->contents;
+            }
+
+            public function readStream(string $path)
+            {
+                $stream = fopen('php://memory', 'r+b');
+                fwrite($stream, $this->contents);
+                rewind($stream);
+
+                return $stream;
+            }
+
+            public function exists(string $path): bool
+            {
+                return true;
+            }
+
+            public function delete(string $path): void
+            {
+            }
+        };
+    }
+}


### PR DESCRIPTION
Первый PR миграции файлового хранилища на S3 (branch-by-abstraction). План: `docs/tasks/s3-migration/plan.md`.

## Что тут
- `ObjectStorageInterface`: добавлены `readStream(): resource` и `delete(): void`.
- Реализации `LocalObjectStorage` и `FlysystemS3ObjectStorage`; `delete()` идемпотентен.
- Новый `TemporaryLocalFile::with()` — скачивает объект во временный файл для парсеров, которым нужен реальный путь (PhpSpreadsheet/ZipArchive/fgetcsv). **Гарантированная чистка `/tmp` через `finally`**, в т.ч. при исключении парсера.

## Важно
- **Additive**: новые методы ещё не вызываются, поведение прода не меняется, драйвер остаётся `local`. Безопасно мержится.
- PHPStan в проекте не установлен — прогнан CS-Fixer (чисто) + `lint:container` (OK).

## Проверка
```
docker compose run --rm -T site-php-cli php bin/phpunit --testsuite unit --filter 'LocalObjectStorageTest|TemporaryLocalFileTest'
```
7 tests / 20 assertions — green.

Stage Report: `docs/tasks/s3-migration/stages/stage-1.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)