### PR TITLE
feat(storage): PR 2 — upload-контроллеры через ObjectStorageInterface

### DIFF
--- a/docs/tasks/s3-migration/plan.md
+++ b/docs/tasks/s3-migration/plan.md
@@ -85,11 +85,18 @@
 - Тесты: unit на `TemporaryLocalFile` (создаёт/удаляет tmp, пробрасывает исключение),
   unit на `Local.readStream/delete`.
 
-### PR 2 — простые store/read сайты → интерфейс — 🟡 MEDIUM
-- Catalog (`ProductImportController` ×2, `ImportProductsFromXlsAction` — часть store),
-  прочие места, где только `storeUploadedFile`/`storeBytes`/`exists`.
-- Пути сохраняем как есть.
-- Тесты: functional на импорт продукта (файл сохраняется и читается по тому же пути).
+### PR 2 — upload-контроллеры (write side) → интерфейс — 🟡 MEDIUM ✅ DONE
+- 5 сайтов с чистой записью загрузки: `Catalog\ProductImportController` (web + Api),
+  `Marketplace\ReconciliationUploadController`, `Marketplace\Inventory\InventoryImportController`,
+  `Marketplace\ReconcileCostsAction`.
+- `storeUploadedFile()` → `write($path, $file->getContent())`; путь сохраняем как есть;
+  `originalFilename` из `$file->getClientOriginalName()`; `fileHash` считаем на месте
+  (`hash('sha256', …)`, как в `StoreRawBatchAction`).
+- **Scope-корректировка:** 2 storeBytes-сайта MarketplaceAds
+  (`DownloadOzonAdReportHandler`, `AdBatchPollerCommand`) вынесены в PR 5 — они плотно
+  связаны с `ExtractBatchesToRawDocumentsAction` (читает `getAbsolutePath` сразу после
+  записи) и их тесты мокают `StorageService` для обеих сторон; узел нельзя разрывать.
+- Тесты: functional `ProductImportUploadTest` — файл сохраняется и читается по пути из БД.
 
 ### PR 3 — тип C: cash-импорт → интерфейс — 🟡 MEDIUM
 - `CashFileImportController` пишет через `write()`, ключ = прежний относительный путь.
@@ -101,11 +108,15 @@
 - `TelegramWebhookController` → `write()`; читатель → `TemporaryLocalFile`.
 - Тесты: приём файла из webhook → обработка воркером.
 
-### PR 5 — тип B: парсеры через `TemporaryLocalFile` — 🟡 MEDIUM
+### PR 5 — тип B: парсеры через `TemporaryLocalFile` (+ узел MarketplaceAds) — 🟡 MEDIUM
 - `LoadMutualSettlementAction`, `OzonReportParserFacade`, `ImportInventoryCostPriceHandler`,
   `ExtractBatchesToRawDocumentsAction`, `DebugReparseMutualSettlementController`.
+- **Плюс из PR 2:** `DownloadOzonAdReportHandler`, `AdBatchPollerCommand` (storeBytes-запись)
+  — мигрируются вместе с `ExtractBatchesToRawDocumentsAction`, т.к. store→getAbsolutePath
+  handoff и общие тесты, мокающие `StorageService`. Обновить эти тесты один раз здесь.
 - Можно разбить на 2 PR: `Marketplace` / `MarketplaceAds`.
-- Тесты: по одному happy-path на каждый парсер (файл читается из хранилища, парсится).
+- Тесты: по одному happy-path на каждый парсер; обновить unit+integration тесты
+  `DownloadOzonAdReportHandler` / `AdBatchPollerCommand` под `ObjectStorageInterface`.
 
 ### PR 6 — тип A: download-контроллеры → `readStream()` — 🟢 LOW
 - 4 контроллера: `getAbsolutePath()`+`BinaryFileResponse` → `readStream()`+`StreamedResponse`.

--- a/docs/tasks/s3-migration/plan.md
+++ b/docs/tasks/s3-migration/plan.md
@@ -130,6 +130,20 @@
 - Тесты: `make stan` (нет внешних импортов `StorageService`).
 
 ### PR 8 — инфра + флип на S3 — 🔴 HIGH (STOP перед выполнением)
+
+> ⛔ **S3-ГЕЙТ (жёсткое предусловие флипа).** Не выставлять
+> `APP_OBJECT_STORAGE_DRIVER=s3`, пока **PR 3, 4 и 5 не в проде**.
+> Причина: часть сайтов уже пишет через `ObjectStorageInterface`, но читает файл
+> обратно через `StorageService::getAbsolutePath()` (локальный диск) — это чинит
+> только PR 5. Под драйвером `local` путь один и тот же, поэтому безопасно; но при
+> флипе на S3 раньше PR 5 такой сайт запишет в S3, а прочитает с локального диска →
+> «файл не найден». Затронуто минимум:
+> `ReconcileCostsAction`, `ReconciliationUploadController` (пишут в PR 2, парсят в PR 5),
+> плюс все тип-B/тип-C потоки до их миграции.
+> **Чек перед флипом:** `grep -rn "getAbsolutePath" src/` вне
+> `Shared/Service/Storage/` должен быть пустым (все читатели переведены на
+> `read()`/`readStream()`/`TemporaryLocalFile`).
+
 1. Бакет timeweb (приватный, TLS-only, versioning вкл., lifecycle 30 дней на
    неактуальные версии; SSE-S3 подготовлен, но выключен).
 2. `APP_OBJECT_STORAGE_*` в host-env + прокинуть в `x-php-env` и в блок env

--- a/docs/tasks/s3-migration/stages/stage-2.md
+++ b/docs/tasks/s3-migration/stages/stage-2.md
@@ -1,0 +1,59 @@
+## Stage 2 (PR 2): Upload-контроллеры (write side) → ObjectStorageInterface — DONE
+
+**Риск:** 🟡 MEDIUM
+**Следующее действие:** continue autonomously (PR 3), сначала PR 2 на ревью/мерж Владельцем
+**Ветка:** стек поверх PR 1 (`feat/s3-migration-pr1-storage-contract`)
+
+### Что сделано
+- 5 сайтов чистой записи загрузки переведены со `StorageService` на `ObjectStorageInterface`:
+  - `Catalog\Controller\ProductImportController` (web)
+  - `Catalog\Controller\Api\ProductImportController`
+  - `Marketplace\Controller\Api\ReconciliationUploadController`
+  - `Marketplace\Controller\Inventory\InventoryImportController`
+  - `Marketplace\Application\ReconcileCostsAction`
+- `storeUploadedFile()` → `write($path, $file->getContent())`. **Пути в БД не меняются.**
+- `originalFilename` берётся из `$file->getClientOriginalName()` (на месте вызова),
+  `fileHash` (нужен в `ReconcileCostsAction`) считается `hash('sha256', $contents)` —
+  по конвенции существующего потребителя интерфейса `StoreRawBatchAction`.
+- Драйвер остаётся `local`, поведение прода не меняется.
+
+### Scope-корректировка (важно ревьюеру)
+Изначально план относил к PR 2 ещё 2 storeBytes-сайта MarketplaceAds
+(`DownloadOzonAdReportHandler`, `AdBatchPollerCommand`). При self-review выяснилось,
+что они плотно связаны с `ExtractBatchesToRawDocumentsAction` (читает `getAbsolutePath`
+сразу после записи — это PR 5) и их unit+integration тесты мокают `StorageService`
+для обеих сторон. Разрывать узел между PR = мокать обе стороны и удвоить возню.
+→ Перенесены в PR 5 (план обновлён). PR 2 = 5 чистых upload-сайтов без тестовой ряби.
+
+### Затронутые файлы
+- `src/Catalog/Controller/ProductImportController.php` — modified
+- `src/Catalog/Controller/Api/ProductImportController.php` — modified
+- `src/Marketplace/Controller/Api/ReconciliationUploadController.php` — modified
+- `src/Marketplace/Controller/Inventory/InventoryImportController.php` — modified
+- `src/Marketplace/Application/ReconcileCostsAction.php` — modified
+- `tests/Functional/Catalog/ProductImportUploadTest.php` — new
+
+### Self-review
+- [x] Scope compliance — только write-сайты; парсеры/скачивание не тронуты (пути идентичны → работают под local)
+- [x] Patterns / naming — hash на месте вызова как в `StoreRawBatchAction`
+- [x] Forbidden actions — none
+- [x] Security — companyId в путях сохранён; `write()`→`storeBytes` добавляет проверку path-traversal (строже, чем `storeUploadedFile`); IDOR не затронут
+- [x] Tests green — functional `ProductImportUploadTest` (6 assertions) + PR1 unit 7/20 не регрессировали
+- [x] DI — `lint:container` OK (менял 5 инъекций)
+- [~] CS-Fixer — на этих файлах пред-существующий долг (Yoda, unused imports, выравнивание): master даёт те же «6 of 7». Мои правки CS-нейтральны; чужой стиль не переписывал (scope-дисциплина)
+- [N/A] PHPStan — в проекте не установлен
+- [N/A] ARCHITECTURE.md — нового Facade/Enum/Entity нет
+
+### Команды для проверки
+- `docker compose run --rm -T site-php-cli php bin/phpunit --testsuite functional --filter ProductImportUploadTest`
+- `docker compose run --rm -T site-php-cli php bin/console lint:container`
+
+### Риски / на что обратить внимание ревьюеру
+- `write()` грузит содержимое загрузки в память (`$file->getContent()`) вместо `move()`.
+  Для xls/xlsx-импортов (мелкие) приемлемо; крупных загрузок среди этих 5 сайтов нет.
+- `ReconciliationUploadController` / `ReconcileCostsAction` пишут через интерфейс, а парсинг
+  (`parseFromStoragePath` / reconciliationAction) пока читает `getAbsolutePath` (PR 5).
+  Под драйвером `local` путь один и тот же — работает; после флипа на S3 это чинит PR 5.
+
+### Открытые вопросы
+- нет

--- a/site/src/Catalog/Controller/Api/ProductImportController.php
+++ b/site/src/Catalog/Controller/Api/ProductImportController.php
@@ -10,7 +10,7 @@ use App\Catalog\Entity\ProductImport;
 use App\Catalog\Infrastructure\Repository\ProductImportRepository;
 use App\Catalog\Message\ImportProductsMessage;
 use App\Shared\Service\ActiveCompanyService;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -26,7 +26,7 @@ final class ProductImportController extends AbstractController
     public function import(
         Request $request,
         ActiveCompanyService $activeCompanyService,
-        StorageService $storageService,
+        ObjectStorageInterface $storage,
         ProductImportRepository $importRepository,
         MessageBusInterface $bus,
     ): JsonResponse {
@@ -46,13 +46,13 @@ final class ProductImportController extends AbstractController
         $importId    = Uuid::uuid7()->toString();
         $relativePath = sprintf('product_imports/%s/%s.%s', $companyId, $importId, $extension);
 
-        $stored = $storageService->storeUploadedFile($file, $relativePath);
+        $stored = $storage->write($relativePath, $file->getContent());
 
         $import = new ProductImport(
             id:           $importId,
             companyId:    $companyId,
-            filePath:     $stored['storagePath'],
-            originalName: $stored['originalFilename'],
+            filePath:     $stored->path,
+            originalName: $file->getClientOriginalName(),
         );
         $importRepository->save($import);
 

--- a/site/src/Catalog/Controller/ProductImportController.php
+++ b/site/src/Catalog/Controller/ProductImportController.php
@@ -8,7 +8,7 @@ use App\Catalog\Entity\ProductImport;
 use App\Catalog\Infrastructure\Repository\ProductImportRepository;
 use App\Catalog\Message\ImportProductsMessage;
 use App\Shared\Service\ActiveCompanyService;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -27,7 +27,7 @@ final class ProductImportController extends AbstractController
     public function import(
         Request $request,
         ActiveCompanyService $activeCompanyService,
-        StorageService $storageService,
+        ObjectStorageInterface $storage,
         ProductImportRepository $importRepository,
         MessageBusInterface $bus,
     ): Response {
@@ -53,13 +53,13 @@ final class ProductImportController extends AbstractController
         $importId     = Uuid::uuid7()->toString();
         $relativePath = sprintf('product_imports/%s/%s.%s', $companyId, $importId, $extension);
 
-        $stored = $storageService->storeUploadedFile($file, $relativePath);
+        $stored = $storage->write($relativePath, $file->getContent());
 
         $import = new ProductImport(
             id:           $importId,
             companyId:    $companyId,
-            filePath:     $stored['storagePath'],
-            originalName: $stored['originalFilename'],
+            filePath:     $stored->path,
+            originalName: $file->getClientOriginalName(),
         );
         $importRepository->save($import);
 

--- a/site/src/Marketplace/Application/ReconcileCostsAction.php
+++ b/site/src/Marketplace/Application/ReconcileCostsAction.php
@@ -8,7 +8,7 @@ use App\Marketplace\Application\Reconciliation\OzonReportParserFacade;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Infrastructure\Query\CostReconciliationQuery;
 use App\Marketplace\Repository\MarketplaceMonthCloseRepository;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
@@ -16,7 +16,7 @@ use Symfony\Component\HttpFoundation\File\UploadedFile;
  * Use-case: загрузить xlsx и выполнить сверку затрат за период.
  *
  * Поток:
- *   1. Сохранить файл через StorageService
+ *   1. Сохранить файл через ObjectStorageInterface
  *   2. Распарсить через OzonReportParserFacade
  *   3. Сверить с данными из marketplace_costs через CostReconciliationQuery
  *   4. Сохранить результат в MarketplaceMonthClose.settings
@@ -27,7 +27,7 @@ final class ReconcileCostsAction
         private readonly OzonReportParserFacade          $parserFacade,
         private readonly CostReconciliationQuery         $reconciliationQuery,
         private readonly MarketplaceMonthCloseRepository $monthCloseRepository,
-        private readonly StorageService                  $storageService,
+        private readonly ObjectStorageInterface          $storage,
     ) {
     }
 
@@ -54,10 +54,11 @@ final class ReconcileCostsAction
             $month,
             Uuid::uuid4()->toString(),
         );
-        $stored = $this->storageService->storeUploadedFile($file, $relativePath);
+        $contents = $file->getContent();
+        $stored = $this->storage->write($relativePath, $contents);
 
         // 2. Распарсить xlsx
-        $reportResult = $this->parserFacade->parseFromStoragePath($stored['storagePath']);
+        $reportResult = $this->parserFacade->parseFromStoragePath($stored->path);
 
         // 3. Сверить с API данными
         $reconciliationResult = $this->reconciliationQuery->reconcile(
@@ -78,9 +79,9 @@ final class ReconcileCostsAction
         }
 
         $monthClose->setCostsReconciliation(array_merge($reconciliationResult, [
-            'file_path'         => $stored['storagePath'],
-            'file_hash'         => $stored['fileHash'],
-            'original_filename' => $stored['originalFilename'],
+            'file_path'         => $stored->path,
+            'file_hash'         => hash('sha256', $contents),
+            'original_filename' => $file->getClientOriginalName(),
             'reconciled_at'     => (new \DateTimeImmutable())->format('Y-m-d H:i:s'),
         ]));
 

--- a/site/src/Marketplace/Controller/Api/ReconciliationUploadController.php
+++ b/site/src/Marketplace/Controller/Api/ReconciliationUploadController.php
@@ -9,7 +9,7 @@ use App\Marketplace\Entity\ReconciliationSession;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Enum\ReconciliationSessionStatus;
 use App\Shared\Service\ActiveCompanyService;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -28,7 +28,7 @@ final class ReconciliationUploadController extends AbstractController
 {
     public function __construct(
         private readonly ActiveCompanyService $activeCompanyService,
-        private readonly StorageService $storageService,
+        private readonly ObjectStorageInterface $storage,
         private readonly RunUserReconciliationAction $reconciliationAction,
         private readonly EntityManagerInterface $em,
     ) {
@@ -83,7 +83,7 @@ final class ReconciliationUploadController extends AbstractController
             $dateFrom->format('Y-m'),
             Uuid::uuid4()->toString(),
         );
-        $stored = $this->storageService->storeUploadedFile($file, $relativePath);
+        $stored = $this->storage->write($relativePath, $file->getContent());
 
         // --- Создание сессии ---
 
@@ -92,8 +92,8 @@ final class ReconciliationUploadController extends AbstractController
             $marketplace,
             $dateFrom,
             $dateTo,
-            $stored['originalFilename'],
-            $stored['storagePath'],
+            $file->getClientOriginalName(),
+            $stored->path,
         );
 
         $this->em->persist($session);

--- a/site/src/Marketplace/Controller/Inventory/InventoryImportController.php
+++ b/site/src/Marketplace/Controller/Inventory/InventoryImportController.php
@@ -7,7 +7,7 @@ namespace App\Marketplace\Controller\Inventory;
 use App\Marketplace\Enum\MarketplaceType;
 use App\Marketplace\Message\ImportInventoryCostPriceMessage;
 use App\Shared\Service\ActiveCompanyService;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -21,9 +21,9 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 final class InventoryImportController extends AbstractController
 {
     public function __construct(
-        private readonly ActiveCompanyService $companyService,
-        private readonly StorageService       $storageService,
-        private readonly MessageBusInterface  $messageBus,
+        private readonly ActiveCompanyService  $companyService,
+        private readonly ObjectStorageInterface $storage,
+        private readonly MessageBusInterface   $messageBus,
     ) {
     }
 
@@ -87,17 +87,19 @@ final class InventoryImportController extends AbstractController
         );
 
         try {
-            $stored = $this->storageService->storeUploadedFile($file, $relativePath);
+            $stored = $this->storage->write($relativePath, $file->getContent());
         } catch (\Exception $e) {
             $this->addFlash('error', 'Ошибка сохранения файла: ' . $e->getMessage());
 
             return $this->redirectToRoute('marketplace_inventory_index');
         }
 
+        $originalFilename = $file->getClientOriginalName();
+
         $this->messageBus->dispatch(new ImportInventoryCostPriceMessage(
             companyId:        $companyId,
-            storagePath:      $stored['storagePath'],
-            originalFilename: $stored['originalFilename'],
+            storagePath:      $stored->path,
+            originalFilename: $originalFilename,
             effectiveFrom:    $effectiveFrom,
             marketplace:      $marketplaceType->value,
             identifierType:   $identifierType,
@@ -105,7 +107,7 @@ final class InventoryImportController extends AbstractController
 
         $this->addFlash('success', sprintf(
             'Файл "%s" принят в обработку. Себестоимость будет обновлена в течение нескольких секунд.',
-            $stored['originalFilename'],
+            $originalFilename,
         ));
 
         return $this->redirectToRoute('marketplace_inventory_index');

--- a/site/tests/Functional/Catalog/ProductImportUploadTest.php
+++ b/site/tests/Functional/Catalog/ProductImportUploadTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Functional\Catalog;
+
+use App\Catalog\Entity\ProductImport;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Component\HttpFoundation\File\UploadedFile;
+
+/**
+ * Регрессия PR 2 (S3-миграция): загрузка импорта идёт через ObjectStorageInterface,
+ * а не напрямую через StorageService. Проверяем, что файл сохранён по тому же пути
+ * (filePath из БД) и читается обратно из хранилища.
+ */
+final class ProductImportUploadTest extends WebTestCaseBase
+{
+    public function testUploadStoresFileThroughObjectStorage(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+
+        $em = $this->em();
+
+        $owner = UserBuilder::aUser()
+            ->withEmail('owner-product-import@example.test')
+            ->build();
+
+        $company = CompanyBuilder::aCompany()
+            ->withId('21111111-1111-1111-1111-1111111110aa')
+            ->withOwner($owner)
+            ->withName('Company Product Import')
+            ->build();
+
+        $em->persist($owner);
+        $em->persist($company);
+        $em->flush();
+
+        $client->loginUser($owner);
+        $this->setClientSessionValue($client, 'active_company_id', $company->getId());
+
+        $payload = 'fake-xlsx-bytes-'.bin2hex(random_bytes(4));
+        $tmpPath = tempnam(sys_get_temp_dir(), 'imp-').'.xlsx';
+        file_put_contents($tmpPath, $payload);
+        $upload = new UploadedFile($tmpPath, 'products.xlsx', null, null, true);
+
+        $client->request('POST', '/catalog/products/import', [], ['file' => $upload]);
+
+        self::assertResponseStatusCodeSame(302);
+
+        /** @var list<ProductImport> $imports */
+        $imports = $em->getRepository(ProductImport::class)->findAll();
+        self::assertCount(1, $imports);
+
+        $import = $imports[0];
+        self::assertSame('products.xlsx', $import->getOriginalName());
+        self::assertStringStartsWith(sprintf('product_imports/%s/', $company->getId()), $import->getFilePath());
+
+        // Файл действительно попал в хранилище по пути из БД и читается обратно.
+        /** @var ObjectStorageInterface $storage */
+        $storage = $client->getContainer()->get(ObjectStorageInterface::class);
+        self::assertTrue($storage->exists($import->getFilePath()));
+        self::assertSame($payload, $storage->read($import->getFilePath()));
+
+        @unlink($tmpPath);
+    }
+}


### PR DESCRIPTION
Второй PR S3-миграции (branch-by-abstraction). **Стек поверх PR 1 #2081** — база = `feat/s3-migration-pr1-storage-contract`, мержить после PR 1.

## Что тут
5 сайтов чистой записи загрузки переведены со `StorageService` на `ObjectStorageInterface`:
- `Catalog\ProductImportController` (web + Api)
- `Marketplace\ReconciliationUploadController`, `InventoryImportController`
- `Marketplace\ReconcileCostsAction`

`storeUploadedFile()` → `write($path, $file->getContent())`. **Пути в БД не меняются**, драйвер остаётся `local`, поведение прода сохранено. `originalFilename` из `getClientOriginalName()`, `fileHash` считается на месте (как в `StoreRawBatchAction`).

## Scope-корректировка
2 storeBytes-сайта MarketplaceAds (`DownloadOzonAdReportHandler`, `AdBatchPollerCommand`) **перенесены в PR 5** — связаны с `ExtractBatchesToRawDocumentsAction` (store→getAbsolutePath) и их тесты мокают `StorageService` для обеих сторон. План обновлён.

## Проверка
- `docker compose run --rm -T site-php-cli php bin/phpunit --testsuite functional --filter ProductImportUploadTest` — green (6 assertions)
- `lint:container` — OK

## Заметки ревьюеру
- `write()` грузит содержимое в память вместо `move()` — ок для мелких xls-импортов.
- CS: пред-существующий долг в этих файлах (Yoda/unused imports/выравнивание) — master даёт те же «6 of 7»; чужой стиль не переписывал.

Stage Report: `docs/tasks/s3-migration/stages/stage-2.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)