### PR TITLE
feat(storage): PR 3 — cash-импорт через ObjectStorageInterface (тип C)

### DIFF
--- a/docs/tasks/s3-migration/stages/stage-3.md
+++ b/docs/tasks/s3-migration/stages/stage-3.md
@@ -1,0 +1,64 @@
+## Stage 3 (PR 3): Тип C — cash-импорт через ObjectStorageInterface — DONE
+
+**Риск:** 🔴 HIGH (money-path + воркер + изменение персистируемых данных)
+**Следующее действие:** 🛑 STOP, ревью Владельцем перед PR 4
+**Ветка:** стек поверх PR 2
+
+### Что сделано (снят межмашинный блокер web↔worker)
+- **`TemporaryLocalFile`** — временный файл получает расширение ключа (readers
+  OpenSpout/PhpSpreadsheet выбирают формат по расширению пути). Аддитивно.
+- **`CashFileImportController`**:
+  - запись загрузки: `file_put_contents(var/storage/...)` → `$storage->write($key, $content)`,
+    ключ `cash-file-imports/{fileHash}{.ext}`;
+  - web-чтения (`mapping`, `preview`): `is_file()`+путь → `$storage->exists($key)` +
+    чтение через `TemporaryLocalFile::with()`;
+  - `commit`: персистит `stored_ext` в `job.options` (было `[]`), чтобы воркер строил
+    точный ключ (без `glob`, который на S3 невозможен).
+- **`CashFileImportService`** (воркер):
+  - `resolveFilePath()` (путь+`is_file`+`glob`) → `resolveStorageKey()` (кандидаты
+    `stored_ext` → расширение из имени файла → без расширения, первый существующий
+    через `exists()`);
+  - `import()` скачивает файл во временную копию через `TemporaryLocalFile::with()`
+    и делегирует в новый `readAndPersist()` — **тело цикла импорта байт-в-байт
+    неизменно** (переименование + вынос, без переноса логики);
+  - убран `projectDir` из конструктора (был только в удалённом `resolveFilePath`).
+
+### In-flight совместимость
+Job'ы, созданные до деплоя (options без `stored_ext`), находятся по кандидату
+«расширение из имени файла». `glob` убран осознанно (S3 его не умеет; под драйвером
+`local` кандидаты покрывают реальные случаи).
+
+### Затронутые файлы
+- `src/Shared/Service/Storage/TemporaryLocalFile.php` — modified (расширение)
+- `src/Cash/Controller/Import/CashFileImportController.php` — modified
+- `src/Cash/Service/Import/File/CashFileImportService.php` — modified
+- `tests/Unit/Shared/Service/Storage/TemporaryLocalFileTest.php` — modified (ext-тест)
+- `tests/Unit/Cash/Service/Import/File/CashFileImportServiceTest.php` — modified (конструктор)
+- `tests/Integration/Cash/Service/Import/File/CashFileImportWorkerStorageTest.php` — new
+
+### Self-review
+- [x] Scope compliance — только cash-импорт (тип C) + необходимая доработка хелпера
+- [x] Patterns / naming — `TemporaryLocalFile` переиспользован (не дублирован cleanup-примитив)
+- [x] Forbidden actions — none (нет new Service, flush только в существующих местах)
+- [x] Security — companyId в путях сохранён; ключи детерминированы; path-traversal прикрыт `storeBytes`
+- [x] Money-path — цикл импорта не изменён (byte-identical), только источник файла
+- [x] Tests green — worker integration (читает из хранилища → 1 транзакция), TemporaryLocalFile ext, cash unit 48/48
+- [x] DI — `lint:container` OK (2 конструктора изменены)
+- [x] CS-Fixer — чисто на 3 изменённых файлах (0 of 3)
+- [N/A] PHPStan — в проекте не установлен
+
+### Команды для проверки
+- `docker compose run --rm -T site-php-cli php bin/phpunit --testsuite integration --filter CashFileImportWorkerStorageTest`
+- `docker compose run --rm -T site-php-cli php bin/phpunit --testsuite unit --filter "Cash|Storage"`
+
+### Риски / на что обратить внимание ревьюеру
+- **Money-path**: изменён только способ получения файла (хранилище вместо диска);
+  логика парсинга/дедупликации/баланса не тронута. Проверить diff `readAndPersist`.
+- **Персист `stored_ext` в `job.options`** — новое поведение записи в БД (без миграции
+  схемы, поле уже JSON). Одобрено Владельцем.
+- **Покрытие**: web-визард (upload→mapping) функциональным тестом не покрыт — крайне
+  многошаговый (CSRF + сессия). Крайняя точка (воркер) покрыта интеграционно, web-write
+  использует тот же `write()`; unit + lint дополняют. Осознанный gap.
+
+### Открытые вопросы
+- нет

--- a/site/src/Cash/Controller/Import/CashFileImportController.php
+++ b/site/src/Cash/Controller/Import/CashFileImportController.php
@@ -12,6 +12,8 @@ use App\Cash\Service\Import\File\FileTabularReader;
 use App\Cash\Service\Import\File\HeaderAutoMapper;
 use App\Company\Entity\User;
 use App\Shared\Service\ActiveCompanyService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Shared\Service\Storage\TemporaryLocalFile;
 use Ramsey\Uuid\Uuid;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
@@ -28,11 +30,27 @@ use Symfony\Component\Security\Http\Attribute\IsGranted;
 #[Route('/cash/import/file')]
 class CashFileImportController extends AbstractController
 {
+    /**
+     * Префикс ключей объектного хранилища для загруженных файлов cash-импорта.
+     * Совпадает с прежним подкаталогом var/storage, поэтому под драйвером local
+     * файлы физически лежат на тех же местах.
+     */
+    private const STORAGE_PREFIX = 'cash-file-imports';
+
     public function __construct(
         private readonly ActiveCompanyService $activeCompanyService,
         private readonly CashFileImportFacade $importFacade,
         private readonly MessageBusInterface $messageBus,
+        private readonly ObjectStorageInterface $storage,
+        private readonly TemporaryLocalFile $temporaryLocalFile,
     ) {
+    }
+
+    private function buildStorageKey(string $fileHash, string $storedExtension): string
+    {
+        $suffix = '' !== $storedExtension ? '.'.$storedExtension : '';
+
+        return sprintf('%s/%s%s', self::STORAGE_PREFIX, $fileHash, $suffix);
     }
 
     #[Route('', name: 'cash_file_import_upload', methods: ['GET'])]
@@ -94,18 +112,12 @@ class CashFileImportController extends AbstractController
         $fileHash = hash('sha256', $fileContent);
         $extension = pathinfo($file->getClientOriginalName(), \PATHINFO_EXTENSION);
         $normalizedExtension = '' !== $extension ? strtolower($extension) : '';
-        $normalizedExtensionWithDot = '' !== $normalizedExtension ? '.'.$normalizedExtension : '';
 
-        $storageDir = sprintf('%s/var/storage/cash-file-imports', $this->getParameter('kernel.project_dir'));
-        if (!is_dir($storageDir) && !mkdir($storageDir, 0775, true) && !is_dir($storageDir)) {
-            $this->addFlash('error', 'Не удалось подготовить директорию для файлов импорта.');
-
-            return $this->redirectToRoute('cash_file_import_upload');
-        }
-
-        $targetPath = sprintf('%s/%s%s', $storageDir, $fileHash, $normalizedExtensionWithDot);
-        if (false === file_put_contents($targetPath, $fileContent)) {
-            $this->addFlash('error', 'Не удалось сохранить файл на диск.');
+        $storageKey = $this->buildStorageKey($fileHash, $normalizedExtension);
+        try {
+            $this->storage->write($storageKey, $fileContent);
+        } catch (\Throwable) {
+            $this->addFlash('error', 'Не удалось сохранить файл импорта.');
 
             return $this->redirectToRoute('cash_file_import_upload');
         }
@@ -142,26 +154,21 @@ class CashFileImportController extends AbstractController
             return $this->redirectToRoute('cash_file_import_upload');
         }
 
-        $extensionSuffix = '';
-        if (is_string($storedExtension) && '' !== $storedExtension) {
-            $extensionSuffix = '.'.$storedExtension;
-        }
+        $storageKey = $this->buildStorageKey($fileHash, is_string($storedExtension) ? $storedExtension : '');
 
-        $filePath = sprintf(
-            '%s/var/storage/cash-file-imports/%s%s',
-            $this->getParameter('kernel.project_dir'),
-            $fileHash,
-            $extensionSuffix
-        );
-
-        if (!is_file($filePath)) {
+        if (!$this->storage->exists($storageKey)) {
             $this->addFlash('error', 'Файл импорта не найден. Загрузите файл заново.');
 
             return $this->redirectToRoute('cash_file_import_upload');
         }
 
-        $headers = $fileTabularReader->readHeader($filePath);
-        $sampleRows = $fileTabularReader->readSampleRows($filePath);
+        [$headers, $sampleRows] = $this->temporaryLocalFile->with(
+            $storageKey,
+            static fn (string $filePath): array => [
+                $fileTabularReader->readHeader($filePath),
+                $fileTabularReader->readSampleRows($filePath),
+            ],
+        );
         $mapping = [];
         if (isset($importPayload['mapping']) && is_array($importPayload['mapping'])) {
             $mapping = $importPayload['mapping'];
@@ -432,26 +439,21 @@ class CashFileImportController extends AbstractController
             return $this->redirectToRoute('cash_file_import_upload');
         }
 
-        $extensionSuffix = '';
-        if (is_string($storedExtension) && '' !== $storedExtension) {
-            $extensionSuffix = '.'.$storedExtension;
-        }
+        $storageKey = $this->buildStorageKey($fileHash, is_string($storedExtension) ? $storedExtension : '');
 
-        $filePath = sprintf(
-            '%s/var/storage/cash-file-imports/%s%s',
-            $this->getParameter('kernel.project_dir'),
-            $fileHash,
-            $extensionSuffix
-        );
-
-        if (!is_file($filePath)) {
+        if (!$this->storage->exists($storageKey)) {
             $this->addFlash('error', 'Файл импорта не найден. Загрузите файл заново.');
 
             return $this->redirectToRoute('cash_file_import_upload');
         }
 
-        $headers = $fileTabularReader->readHeader($filePath);
-        $sampleRows = $fileTabularReader->readSampleRows($filePath, 100);
+        [$headers, $sampleRows] = $this->temporaryLocalFile->with(
+            $storageKey,
+            static fn (string $filePath): array => [
+                $fileTabularReader->readHeader($filePath),
+                $fileTabularReader->readSampleRows($filePath, 100),
+            ],
+        );
 
         $headerLabels = [];
         foreach ($headers as $index => $header) {
@@ -529,6 +531,8 @@ class CashFileImportController extends AbstractController
             return $this->redirectToRoute('cash_file_import_upload');
         }
 
+        $storedExtension = $importPayload['stored_ext'] ?? null;
+
         $accountId = $importPayload['account_id'] ?? null;
         if (!$accountId) {
             $this->addFlash('error', 'Не удалось определить кассу для импорта.');
@@ -568,7 +572,7 @@ class CashFileImportController extends AbstractController
             $fileName,
             $fileHash,
             $mapping,
-            [],
+            is_string($storedExtension) && '' !== $storedExtension ? ['stored_ext' => $storedExtension] : [],
             $userIdentifier
         );
         $this->importFacade->commitJob($job);

--- a/site/src/Cash/Service/Import/File/CashFileImportService.php
+++ b/site/src/Cash/Service/Import/File/CashFileImportService.php
@@ -8,9 +8,11 @@ use App\Cash\Repository\Transaction\CashTransactionRepository;
 use App\Cash\Service\Accounts\AccountBalanceService;
 use App\Cash\Service\Import\ImportLogger;
 use App\Company\Entity\Company;
-use App\Company\Enum\CounterpartyType;
 use App\Company\Entity\Counterparty;
+use App\Company\Enum\CounterpartyType;
 use App\Company\Repository\CounterpartyRepository;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Shared\Service\Storage\TemporaryLocalFile;
 use Doctrine\ORM\EntityManagerInterface;
 use OpenSpout\Reader\CSV\Options as CsvOptions;
 use OpenSpout\Reader\CSV\Reader as CsvReader;
@@ -18,7 +20,6 @@ use OpenSpout\Reader\ReaderInterface;
 use OpenSpout\Reader\XLS\Reader as XlsReader;
 use OpenSpout\Reader\XLSX\Reader as XlsxReader;
 use Ramsey\Uuid\Uuid;
-use Symfony\Component\DependencyInjection\Attribute\Autowire;
 
 final class CashFileImportService
 {
@@ -32,12 +33,25 @@ final class CashFileImportService
         private readonly ImportLogger $importLogger,
         private readonly EntityManagerInterface $entityManager,
         private readonly AccountBalanceService $accountBalanceService,
-        #[Autowire('%kernel.project_dir%')]
-        private readonly string $projectDir,
+        private readonly ObjectStorageInterface $objectStorage,
+        private readonly TemporaryLocalFile $temporaryLocalFile,
     ) {
     }
 
     public function import(CashFileImportJob $job): void
+    {
+        $storageKey = $this->resolveStorageKey($job);
+
+        // Файл читается воркером через объектное хранилище: скачиваем во временную
+        // локальную копию (readers OpenSpout требуют реальный путь), обрабатываем,
+        // TemporaryLocalFile гарантированно удаляет её после.
+        $this->temporaryLocalFile->with(
+            $storageKey,
+            fn (string $filePath) => $this->readAndPersist($filePath, $job),
+        );
+    }
+
+    private function readAndPersist(string $filePath, CashFileImportJob $job): void
     {
         $company = $job->getCompany();
         $moneyAccount = $job->getMoneyAccount();
@@ -45,8 +59,6 @@ final class CashFileImportService
         $mapping = $job->getMapping();
         $companyId = $company->getId();
         $accountId = $moneyAccount->getId();
-
-        $filePath = $this->resolveFilePath($job);
 
         $created = 0;
         $createdMinDate = null;
@@ -213,9 +225,14 @@ final class CashFileImportService
         }
     }
 
-    private function resolveFilePath(CashFileImportJob $job): string
+    /**
+     * Ключ файла в объектном хранилище. Кандидаты в порядке приоритета
+     * (stored_ext → расширение из имени файла → без расширения) — первый,
+     * который существует. Кандидат по имени файла сохраняет совместимость
+     * с job'ами, созданными до персиста stored_ext в options.
+     */
+    private function resolveStorageKey(CashFileImportJob $job): string
     {
-        $storageDir = sprintf('%s/var/storage/cash-file-imports', $this->projectDir);
         $fileHash = $job->getFileHash();
 
         $extensions = [];
@@ -233,23 +250,16 @@ final class CashFileImportService
             $extensions[] = strtolower($fileExtension);
         }
 
-        $extensions = array_values(array_unique($extensions));
+        $candidates = [];
+        foreach (array_values(array_unique($extensions)) as $extension) {
+            $candidates[] = sprintf('cash-file-imports/%s.%s', $fileHash, $extension);
+        }
+        $candidates[] = sprintf('cash-file-imports/%s', $fileHash);
 
-        foreach ($extensions as $extension) {
-            $candidate = sprintf('%s/%s.%s', $storageDir, $fileHash, $extension);
-            if (is_file($candidate)) {
+        foreach ($candidates as $candidate) {
+            if ($this->objectStorage->exists($candidate)) {
                 return $candidate;
             }
-        }
-
-        $noExtensionPath = sprintf('%s/%s', $storageDir, $fileHash);
-        if (is_file($noExtensionPath)) {
-            return $noExtensionPath;
-        }
-
-        $fallbackMatches = glob(sprintf('%s/%s.*', $storageDir, $fileHash)) ?: [];
-        if ([] !== $fallbackMatches) {
-            return $fallbackMatches[0];
         }
 
         throw new \RuntimeException(sprintf('Import file not found for hash %s', $fileHash));

--- a/site/src/Shared/Service/Storage/TemporaryLocalFile.php
+++ b/site/src/Shared/Service/Storage/TemporaryLocalFile.php
@@ -18,6 +18,9 @@ final readonly class TemporaryLocalFile
     }
 
     /**
+     * Временный файл получает то же расширение, что и ключ объекта — некоторые
+     * парсеры/ридеры (OpenSpout, PhpSpreadsheet) выбирают формат по расширению пути.
+     *
      * @template T
      *
      * @param callable(string $localPath): T $consumer
@@ -29,6 +32,17 @@ final readonly class TemporaryLocalFile
         $tmpPath = tempnam(sys_get_temp_dir(), 'objstore-');
         if (false === $tmpPath) {
             throw new ObjectStorageException('Failed to allocate a temporary file.');
+        }
+
+        $extension = pathinfo($path, \PATHINFO_EXTENSION);
+        if ('' !== $extension) {
+            $tmpWithExt = $tmpPath.'.'.$extension;
+            if (!@rename($tmpPath, $tmpWithExt)) {
+                @unlink($tmpPath);
+
+                throw new ObjectStorageException(sprintf('Failed to prepare a temporary file for object "%s".', $path));
+            }
+            $tmpPath = $tmpWithExt;
         }
 
         try {

--- a/site/tests/Integration/Cash/Service/Import/File/CashFileImportWorkerStorageTest.php
+++ b/site/tests/Integration/Cash/Service/Import/File/CashFileImportWorkerStorageTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Integration\Cash\Service\Import\File;
+
+use App\Cash\Entity\Import\CashFileImportJob;
+use App\Cash\Entity\Transaction\CashTransaction;
+use App\Cash\Service\Import\File\CashFileImportService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Tests\Builders\Cash\MoneyAccountBuilder;
+use App\Tests\Builders\Company\CompanyBuilder;
+use App\Tests\Builders\Company\UserBuilder;
+use App\Tests\Support\Kernel\IntegrationTestCase;
+use Ramsey\Uuid\Uuid;
+
+/**
+ * Регрессия PR 3 (S3-миграция, тип C): воркер импорта читает файл через
+ * ObjectStorageInterface, а не с локального диска по пути. Это снимает
+ * межмашинную зависимость web↔worker.
+ */
+final class CashFileImportWorkerStorageTest extends IntegrationTestCase
+{
+    public function testWorkerReadsImportFileFromObjectStorage(): void
+    {
+        $owner = UserBuilder::aUser()->withEmail('cash-import-worker@example.test')->build();
+        $company = CompanyBuilder::aCompany()
+            ->withId('44444444-4444-4444-4444-444444444401')
+            ->withOwner($owner)
+            ->withName('Cash Import Worker Co')
+            ->build();
+        $account = MoneyAccountBuilder::aMoneyAccount()
+            ->withId('44444444-4444-4444-4444-4444444444a1')
+            ->forCompany($company)
+            ->withCurrency('RUB')
+            ->build();
+
+        $this->em->persist($owner);
+        $this->em->persist($company);
+        $this->em->persist($account);
+        $this->em->flush();
+
+        $csv = "Дата;Сумма;Назначение\n01.12.2025;1000,50;Оплата услуг\n";
+        $fileHash = hash('sha256', $csv);
+        $storageKey = sprintf('cash-file-imports/%s.csv', $fileHash);
+
+        /** @var ObjectStorageInterface $storage */
+        $storage = self::getContainer()->get(ObjectStorageInterface::class);
+        $storage->write($storageKey, $csv);
+
+        $job = new CashFileImportJob(
+            Uuid::uuid4()->toString(),
+            $company,
+            $account,
+            'cash:file',
+            'bank.csv',
+            $fileHash,
+            ['date' => 'Дата', 'amount' => 'Сумма', 'description' => 'Назначение'],
+            ['stored_ext' => 'csv'],
+        );
+        $this->em->persist($job);
+        $this->em->flush();
+
+        /** @var CashFileImportService $service */
+        $service = self::getContainer()->get(CashFileImportService::class);
+        $service->import($job);
+
+        $transactions = $this->em->getRepository(CashTransaction::class)->findBy(['company' => $company]);
+        self::assertCount(1, $transactions, 'Воркер должен был прочитать файл из хранилища и создать транзакцию.');
+
+        $storage->delete($storageKey);
+    }
+}

--- a/site/tests/Unit/Cash/Service/Import/File/CashFileImportServiceTest.php
+++ b/site/tests/Unit/Cash/Service/Import/File/CashFileImportServiceTest.php
@@ -10,6 +10,8 @@ use App\Cash\Service\Import\File\CashFileImportService;
 use App\Cash\Service\Import\File\CashFileRowNormalizer;
 use App\Cash\Service\Import\ImportLogger;
 use App\Company\Repository\CounterpartyRepository;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Shared\Service\Storage\TemporaryLocalFile;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
 
@@ -24,7 +26,8 @@ final class CashFileImportServiceTest extends TestCase
             new ImportLogger($this->createMock(EntityManagerInterface::class)),
             $this->createMock(EntityManagerInterface::class),
             $this->createMock(AccountBalanceService::class),
-            '/tmp'
+            $objectStorage = $this->createMock(ObjectStorageInterface::class),
+            new TemporaryLocalFile($objectStorage),
         );
 
         $method = new \ReflectionMethod(CashFileImportService::class, 'makeDedupeHash');

--- a/site/tests/Unit/Shared/Service/Storage/TemporaryLocalFileTest.php
+++ b/site/tests/Unit/Shared/Service/Storage/TemporaryLocalFileTest.php
@@ -26,6 +26,18 @@ final class TemporaryLocalFileTest extends TestCase
         self::assertSame('parsed', $result);
     }
 
+    public function testTemporaryFileKeepsExtensionOfKey(): void
+    {
+        $temporaryLocalFile = new TemporaryLocalFile($this->storageReturning('col1;col2'));
+
+        $seenExtension = null;
+        $temporaryLocalFile->with('cash-file-imports/abc123.csv', function (string $localPath) use (&$seenExtension): void {
+            $seenExtension = pathinfo($localPath, \PATHINFO_EXTENSION);
+        });
+
+        self::assertSame('csv', $seenExtension);
+    }
+
     public function testTemporaryFileRemovedAfterSuccess(): void
     {
         $temporaryLocalFile = new TemporaryLocalFile($this->storageReturning('payload'));


### PR DESCRIPTION
Третий PR S3-миграции. **Стек поверх PR 2 #2082** — база = `feat/s3-migration-pr2-upload-controllers`, мержить после PR 1→2.

## Зачем (главный блокер)
Web-визард писал загрузку в локальный docker-том, а воркер читал её **по абсолютному пути** — web и worker обязаны быть на одной машине. Теперь оба ходят через `ObjectStorageInterface`. **Это снимает межмашинную зависимость.** Драйвер остаётся `local`, файлы физически на тех же путях `var/storage/cash-file-imports/...`.

## Что тут
- **`TemporaryLocalFile`**: временная копия сохраняет расширение ключа (OpenSpout/PhpSpreadsheet выбирают reader по расширению пути).
- **`CashFileImportController`**: запись через `write()`; web-чтения (`mapping`/`preview`) через `TemporaryLocalFile` + `exists()`; `commit` персистит `stored_ext` в `job.options` (чтобы воркер строил точный ключ, `glob` на S3 невозможен).
- **`CashFileImportService`** (воркер): `resolveFilePath` → `resolveStorageKey` (кандидаты через `exists()`, in-flight совместимость через расширение из имени файла); `import()` качает temp-копию через `TemporaryLocalFile` и делегирует в `readAndPersist` — **цикл импорта байт-в-байт неизменен**; убран `projectDir`.

## Money-path
Изменён только способ получения файла (хранилище вместо диска). Логика парсинга/дедупликации/пересчёта баланса не тронута.

## Проверка
- `docker compose run --rm -T site-php-cli php bin/phpunit --testsuite integration --filter CashFileImportWorkerStorageTest` — воркер читает из хранилища → создаёт транзакцию ✓
- `--testsuite unit --filter "Cash|Storage"` — 48/48 ✓
- `lint:container` OK, CS чисто на изменённых файлах.

## Заметки ревьюеру
- Персист `stored_ext` в `job.options` — новое поведение записи (без миграции схемы). Одобрено Владельцем.
- `glob`-фолбэк убран осознанно (S3 не умеет); кандидаты покрывают реальные случаи + in-flight job'ы.
- Web-визард функциональным тестом не покрыт (многошаговый CSRF+сессия) — крайняя точка (воркер) покрыта интеграционно. Осознанный gap.

Stage Report: `docs/tasks/s3-migration/stages/stage-3.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)