### PR TITLE
feat(storage): PR 4 — telegram-импорт через ObjectStorageInterface (тип C)

### DIFF
--- a/docs/tasks/s3-migration/stages/stage-4.md
+++ b/docs/tasks/s3-migration/stages/stage-4.md
@@ -1,0 +1,52 @@
+## Stage 4 (PR 4): Тип C — telegram-импорт через ObjectStorageInterface — DONE
+
+**Риск:** 🟡 MEDIUM
+**Следующее действие:** continue autonomously (PR 5), сначала PR 4 на ревью/мерж Владельцем
+**Ветка:** от чистого master (стек расстекан после мержа PR 1–3)
+
+### Что сделано
+- `TelegramWebhookController::handleDocument` — запись скачанного из Telegram файла:
+  `mkdir + file_put_contents(var/storage/telegram-imports/...)` → `$storage->write($key, $content)`,
+  ключ `telegram-imports/{fileHash}{.ext}`.
+- Инъекция `ObjectStorageInterface $storage` в конструктор (перед параметрами со
+  значениями по умолчанию; строковые параметры биндятся по имени → вставка безопасна).
+- `fileHash` в `ImportJob` не меняется; расширение сохраняется в ключе.
+
+### Важное наблюдение
+Telegram-импорт сейчас **write-only**: webhook скачивает файл, кладёт в хранилище и
+создаёт `ImportJob`, но **читателя/воркера нет** (в коде явный комментарий «В проекте
+пока нет очереди/команды для автоматического импорта»). Поэтому PR 4 мигрирует только
+запись; будущий импортёр восстановит ключ из `ImportJob.fileHash` + расширения имени
+файла (как в cash, PR 3). Межмашинная запись теперь идёт в объектное хранилище.
+
+### Затронутые файлы
+- `src/Telegram/Controller/TelegramWebhookController.php` — modified (write + конструктор)
+- `tests/Telegram/Functional/TelegramWebhookCashTransactionTest.php` — modified (новый тест + `postDocument`)
+
+### Self-review
+- [x] Scope compliance — только запись telegram-документа
+- [x] Patterns / naming — ключ по схеме, как в cash
+- [x] Forbidden actions — none
+- [x] Security — companyId в `ImportJob`; ключ content-addressed (как было); секрет вебхука не логируется
+- [x] Tests green — новый `testDocumentUploadIsStoredInObjectStorage` (webhook пишет в хранилище, читается обратно, `ImportJob` создан); весь класс `TelegramWebhookCashTransactionTest` 6/6
+- [x] DI — `lint:container` OK (конструктор изменён, bind по имени)
+- [x] CS-Fixer — чисто на 2 изменённых файлах (0 of 2)
+- [N/A] PHPStan — в проекте не установлен
+
+### Пред-существующее (НЕ в scope PR 4)
+Полный `--testsuite telegram` даёт 16 ошибок в `BotLinkServiceTest`/`BotLinkTest`
+(`TypeError` в `BotLinkService` — Company вместо string id). Проверено: **падает на
+master** с застешенными правками PR 4. Deep-link токены, к хранилищу отношения не имеют.
+Отдельный баг, вне scope.
+
+### Команды для проверки
+- `docker compose run --rm -T site-php-cli php bin/phpunit --filter TelegramWebhookCashTransactionTest`
+
+### Риски / на что обратить внимание ревьюеру
+- Ключи telegram остаются content-addressed (без `companyId`) — сохранение поведения,
+  как в cash (PR 3). Follow-up: company-scope при переходе на целевую схему.
+- Web-only поток; при появлении воркера-импортёра он должен читать через
+  `TemporaryLocalFile` (тип B).
+
+### Открытые вопросы
+- нет

--- a/site/src/Telegram/Controller/TelegramWebhookController.php
+++ b/site/src/Telegram/Controller/TelegramWebhookController.php
@@ -7,6 +7,7 @@ namespace App\Telegram\Controller;
 use App\Cash\Entity\Accounts\MoneyAccount;
 use App\Cash\Exception\CurrencyMismatchException;
 use App\Shared\Domain\Exception\UserFacingException;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use App\Telegram\Application\CreateTelegramCashTransactionAction;
 use App\Telegram\Application\DTO\CreateTelegramCashTransactionCommand;
 use App\Telegram\Entity\ClientBinding;
@@ -35,6 +36,7 @@ final class TelegramWebhookController extends AbstractController
         private readonly HttpClientInterface $httpClient,
         private readonly LoggerInterface $logger,
         private readonly CreateTelegramCashTransactionAction $createTelegramCashTransactionAction,
+        private readonly ObjectStorageInterface $storage,
         private readonly string $telegramWebhookSecret = '',
         private readonly string $telegramApiBaseUrl = 'https://api.telegram.org',
     ) {
@@ -735,14 +737,11 @@ final class TelegramWebhookController extends AbstractController
         $extension = pathinfo($originalFilename, \PATHINFO_EXTENSION);
         $normalizedExtension = '' !== $extension ? '.'.strtolower($extension) : '';
 
-        $storageDir = sprintf('%s/var/storage/telegram-imports', $this->getParameter('kernel.project_dir'));
-        if (!is_dir($storageDir) && !mkdir($storageDir, 0775, true) && !is_dir($storageDir)) {
-            return $this->respondWithMessage($bot, $message, 'Не удалось подготовить директорию для файлов импорта.');
-        }
-
-        $targetPath = sprintf('%s/%s%s', $storageDir, $fileHash, $normalizedExtension);
-        if (false === file_put_contents($targetPath, $fileContent)) {
-            return $this->respondWithMessage($bot, $message, 'Не удалось сохранить файл на диск.');
+        $storageKey = sprintf('telegram-imports/%s%s', $fileHash, $normalizedExtension);
+        try {
+            $this->storage->write($storageKey, $fileContent);
+        } catch (\Throwable) {
+            return $this->respondWithMessage($bot, $message, 'Не удалось сохранить файл импорта.');
         }
 
         // Создаем задачу импорта, чтобы не смешивать загрузку из Telegram с существующей системой импорта

--- a/site/tests/Telegram/Functional/TelegramWebhookCashTransactionTest.php
+++ b/site/tests/Telegram/Functional/TelegramWebhookCashTransactionTest.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace App\Tests\Telegram\Functional;
 
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use App\Telegram\Entity\ClientBinding;
+use App\Telegram\Entity\ImportJob;
 use App\Telegram\Entity\TelegramBot;
 use App\Telegram\Entity\TelegramUser;
 use App\Tests\Builders\Cash\MoneyAccountBuilder;
@@ -117,6 +119,70 @@ final class TelegramWebhookCashTransactionTest extends WebTestCaseBase
         self::assertResponseIsSuccessful();
         $body = $this->lastSentMessageText($captured);
         self::assertStringContainsString('расход', $body);
+    }
+
+    public function testDocumentUploadIsStoredInObjectStorage(): void
+    {
+        $client = static::createClient();
+        $this->resetDb();
+        $this->seedBoundUserWithAccount(financeLockBefore: null);
+
+        $csv = "Дата;Сумма\n01.12.2025;1000\n";
+        $client->getContainer()->set('http_client', new MockHttpClient(
+            static function (string $method, string $url) use ($csv): MockResponse {
+                if (str_contains($url, '/getFile')) {
+                    return new MockResponse(json_encode(
+                        ['ok' => true, 'result' => ['file_path' => 'documents/file_5.csv']],
+                        \JSON_THROW_ON_ERROR,
+                    ));
+                }
+                if (str_contains($url, '/file/bot')) {
+                    return new MockResponse($csv);
+                }
+
+                return new MockResponse(json_encode(['ok' => true, 'result' => true], \JSON_THROW_ON_ERROR));
+            },
+        ));
+
+        $this->postDocument($client, 'statement.csv');
+
+        self::assertResponseIsSuccessful();
+
+        /** @var ObjectStorageInterface $storage */
+        $storage = $client->getContainer()->get(ObjectStorageInterface::class);
+        $key = sprintf('telegram-imports/%s.csv', hash('sha256', $csv));
+
+        self::assertTrue($storage->exists($key), 'Файл документа должен быть записан в объектное хранилище.');
+        self::assertSame($csv, $storage->read($key));
+        self::assertCount(1, $this->em()->getRepository(ImportJob::class)->findAll());
+
+        $storage->delete($key);
+    }
+
+    private function postDocument(KernelBrowser $client, string $fileName): void
+    {
+        $payload = [
+            'update_id' => 2002,
+            'message' => [
+                'message_id' => 77,
+                'date' => 1718000000,
+                'chat' => ['id' => self::CHAT_ID],
+                'from' => ['id' => (int) self::TG_USER_ID, 'first_name' => 'Test'],
+                'document' => ['file_id' => 'FILE123', 'file_name' => $fileName],
+            ],
+        ];
+
+        $client->request(
+            'POST',
+            '/telegram/webhook',
+            [],
+            [],
+            [
+                'CONTENT_TYPE' => 'application/json',
+                'HTTP_X_TELEGRAM_BOT_API_SECRET_TOKEN' => 'test-secret-123',
+            ],
+            json_encode($payload, \JSON_THROW_ON_ERROR),
+        );
     }
 
     private function seedBoundUserWithAccount(?\DateTimeImmutable $financeLockBefore): void


### PR DESCRIPTION
Четвёртый PR S3-миграции. От чистого master (стек расстекан после мержа PR 1–3).

## Что тут
`TelegramWebhookController::handleDocument`: запись скачанного из Telegram файла `file_put_contents(var/storage/telegram-imports/...)` → `$storage->write($key, $content)`, ключ `telegram-imports/{fileHash}{.ext}`. Инъекция `ObjectStorageInterface`. Драйвер `local`, файлы физически там же.

## Важно: telegram-импорт сейчас write-only
Webhook скачивает файл, кладёт в хранилище, создаёт `ImportJob` — но **читателя/воркера ещё нет** (в коде явный комментарий). Поэтому мигрирована только запись. Будущий импортёр восстановит ключ из `ImportJob.fileHash` + расширения имени (как cash, PR 3), и читать должен через `TemporaryLocalFile`.

## Проверка
- `docker compose run --rm -T site-php-cli php bin/phpunit --filter TelegramWebhookCashTransactionTest` — 6/6 (вкл. новый `testDocumentUploadIsStoredInObjectStorage`: webhook пишет в хранилище, читается обратно, ImportJob создан)
- `lint:container` OK, CS чисто (0 of 2)

## Заметки ревьюеру
- Ключи telegram остаются content-addressed (без companyId) — сохранение поведения, как в cash. Follow-up при переходе на целевую схему.
- **Пред-существующее (не PR 4):** `--testsuite telegram` даёт 16 ошибок в `BotLinkService(Test)` (`TypeError`, Company вместо string id) — падает и на master, к хранилищу не относится.

Stage Report: `docs/tasks/s3-migration/stages/stage-4.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)