### PR TITLE
feat(storage): PR 5a — парсеры Marketplace/Catalog через TemporaryLocalFile (тип B)

### DIFF
--- a/docs/tasks/s3-migration/stages/stage-5a.md
+++ b/docs/tasks/s3-migration/stages/stage-5a.md
@@ -1,0 +1,54 @@
+## Stage 5a (PR 5a): Тип B — парсеры Marketplace/Catalog/Analytics — DONE
+
+**Риск:** 🟡 MEDIUM (money-adjacent: парсеры сверок/себестоимости)
+**Следующее действие:** continue autonomously (PR 5b), сначала PR 5a на ревью/мерж
+**Ветка:** от чистого master
+
+### Что сделано
+5 парсер-сайтов переведены с `StorageService::getAbsolutePath()` + прямого парсинга
+на `TemporaryLocalFile::with()` (скачивание во временную копию с расширением ключа):
+
+| Сайт | Тип | Изменение |
+|---|---|---|
+| `Catalog\ImportProductsFromXlsAction` | read | `getAbsolutePath`+`parser->parse` → `with()` |
+| `Marketplace\Reconciliation\OzonReportParserFacade` | read | `parseFromStoragePath` → `with()` (parseFromPath оставлен) |
+| `Marketplace\ImportInventoryCostPriceHandler` | read | обёрнут вызов action (temp живёт весь импорт) |
+| `MarketplaceAnalytics\DebugReparseMutualSettlementController` | read | `exists()`→404 + `with()` для парсинга |
+| `Marketplace\LoadMutualSettlementAction` | **write+read** | `ensureDir`+`file_put_contents` → `write()`; `parse` → `with()` |
+
+MarketplaceAds (`ExtractBatchesToRawDocumentsAction` + 2 storeBytes-сайта) — в PR 5b.
+`DebugDownloadRawDocumentController` (тип A, download) — в PR 6.
+
+### Расширение ключей
+Все ключи содержат расширение (`.xlsx` и т.п.), `TemporaryLocalFile` (PR 3) отдаёт temp
+с тем же расширением → парсеры (PhpSpreadsheet/XlsxReader) выбирают формат корректно.
+
+### Затронутые файлы
+- `src/Catalog/Application/ImportProductsFromXlsAction.php` — modified
+- `src/Marketplace/Application/Reconciliation/OzonReportParserFacade.php` — modified
+- `src/Marketplace/MessageHandler/ImportInventoryCostPriceHandler.php` — modified
+- `src/MarketplaceAnalytics/Controller/Api/DebugReparseMutualSettlementController.php` — modified
+- `src/Marketplace/Application/LoadMutualSettlementAction.php` — modified
+- `tests/Unit/Marketplace/Application/Reconciliation/OzonReportParserFacadeStorageTest.php` — new
+
+### Self-review
+- [x] Scope compliance — только 5 парсеров (без MarketplaceAds/download)
+- [x] Patterns / naming — `TemporaryLocalFile::with()` везде; `LoadMutualSettlement` write через `write()`
+- [x] Forbidden actions — none
+- [x] Security — companyId в путях/ключах сохранён; IDOR не затронут
+- [x] Tests green — новый `OzonReportParserFacadeStorageTest` (storage→temp .xlsx→reader→cleanup, 6 assertions); регрессия unit Reconciliation/Catalog 14/14
+- [x] DI — `lint:container` OK (5 конструкторов)
+- [~] CS-Fixer — пред-существующий долг выравнивания (master даёт те же 5 of 5); новый тест чист; чужой стиль не переписывал
+- [N/A] PHPStan — в проекте не установлен
+
+### Команды для проверки
+- `docker compose run --rm -T site-php-cli php bin/phpunit --filter OzonReportParserFacadeStorageTest`
+- `docker compose run --rm -T site-php-cli php bin/console lint:container`
+
+### Риски / на что обратить внимание ревьюеру
+- `LoadMutualSettlementAction` — единственный write+read; проверить, что `write($relativePath, $binaryContent)` + последующий `with($relativePath, parse)` согласованы (ключ один и тот же). Под `local` файл физически там же.
+- Money-adjacent: логика парсинга/агрегации не менялась, только источник файла (хранилище вместо диска).
+- `ImportInventoryCostPriceHandler`: убран явный `file_exists`-чек; отсутствие файла теперь бросает `ObjectStorageException` из `readStream` → тот же catch → jobLog.fail + rethrow (эквивалентно).
+
+### Открытые вопросы
+- нет

--- a/site/src/Catalog/Application/ImportProductsFromXlsAction.php
+++ b/site/src/Catalog/Application/ImportProductsFromXlsAction.php
@@ -19,7 +19,7 @@ use App\Catalog\Infrastructure\Repository\ProductImportRepository;
 use App\Catalog\Infrastructure\XlsProductRowParser;
 use App\Company\Entity\Company;
 use App\Company\Facade\CompanyFacade;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\TemporaryLocalFile;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
 
@@ -44,7 +44,7 @@ final class ImportProductsFromXlsAction
         private readonly InternalArticleGenerator $articleGenerator,
         private readonly SetPurchasePriceAction $setPurchasePriceAction,
         private readonly CompanyFacade $companyFacade,
-        private readonly StorageService $storageService,
+        private readonly TemporaryLocalFile $temporaryLocalFile,
         private readonly EntityManagerInterface $entityManager,
     ) {
     }
@@ -61,8 +61,10 @@ final class ImportProductsFromXlsAction
                 throw new \DomainException(sprintf('Компания "%s" не найдена.', $command->companyId));
             }
 
-            $filePath = $this->storageService->getAbsolutePath($import->getFilePath());
-            $rows     = $this->parser->parse($filePath);
+            $rows = $this->temporaryLocalFile->with(
+                $import->getFilePath(),
+                fn (string $filePath) => $this->parser->parse($filePath),
+            );
             $result   = $this->processRows($rows, $command->companyId, $company);
 
             $import->markDone(

--- a/site/src/Marketplace/Application/LoadMutualSettlementAction.php
+++ b/site/src/Marketplace/Application/LoadMutualSettlementAction.php
@@ -12,7 +12,8 @@ use App\Marketplace\Enum\PipelineStatus;
 use App\Marketplace\Enum\PipelineStep;
 use App\Marketplace\Infrastructure\Api\Ozon\OzonMutualSettlementClient;
 use App\Shared\Service\AppLogger;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Shared\Service\Storage\TemporaryLocalFile;
 use Doctrine\ORM\EntityManagerInterface;
 use Ramsey\Uuid\Uuid;
 
@@ -32,7 +33,8 @@ final class LoadMutualSettlementAction
     public function __construct(
         private readonly OzonMutualSettlementClient $client,
         private readonly OzonMutualSettlementProcessor $processor,
-        private readonly StorageService $storageService,
+        private readonly ObjectStorageInterface $storage,
+        private readonly TemporaryLocalFile $temporaryLocalFile,
         private readonly EntityManagerInterface $em,
         private readonly AppLogger $appLogger,
     ) {
@@ -116,13 +118,8 @@ final class LoadMutualSettlementAction
             $extension,
         );
 
-        // Сохраняем файл на диск
-        $dir = sprintf('%s/%s', self::STORAGE_DIR, $companyId);
-        $this->storageService->ensureDir($dir);
-        $absolutePath = $this->storageService->getAbsolutePath($relativePath);
-        if (false === file_put_contents($absolutePath, $binaryContent)) {
-            throw new \RuntimeException(sprintf('Не удалось сохранить файл на диск: %s', $relativePath));
-        }
+        // Сохраняем файл в объектное хранилище
+        $this->storage->write($relativePath, $binaryContent);
 
         $this->appLogger->info('LoadMutualSettlement: файл сохранён', [
             'companyId' => $companyId,
@@ -142,7 +139,10 @@ final class LoadMutualSettlementAction
         $processingStatus = PipelineStatus::COMPLETED;
 
         try {
-            $parsed = $this->processor->parse($absolutePath);
+            $parsed = $this->temporaryLocalFile->with(
+                $relativePath,
+                fn (string $absolutePath): array => $this->processor->parse($absolutePath),
+            );
             $rawData['parsed'] = $parsed;
             $recordsCount = $parsed['meta']['rows_parsed'] ?? $parsed['totals']['rows_count'] ?? 0;
 

--- a/site/src/Marketplace/Application/Reconciliation/OzonReportParserFacade.php
+++ b/site/src/Marketplace/Application/Reconciliation/OzonReportParserFacade.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace App\Marketplace\Application\Reconciliation;
 
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\TemporaryLocalFile;
 
 /**
  * Оркестрирует парсинг xlsx отчёта «Детализация начислений» Ozon.
@@ -19,7 +19,7 @@ final class OzonReportParserFacade
         private readonly BaseSignResolverService  $baseSignResolver,
         private readonly RowClassifierService     $classifier,
         private readonly ReportAggregatorService  $aggregator,
-        private readonly StorageService           $storageService,
+        private readonly TemporaryLocalFile        $temporaryLocalFile,
     ) {
     }
 
@@ -38,14 +38,15 @@ final class OzonReportParserFacade
     }
 
     /**
-     * Парсит файл по relative path из StorageService.
+     * Парсит файл по ключу в объектном хранилище (скачивая во временную локальную копию).
      *
      * @return array<string, mixed> ReportResult
      */
     public function parseFromStoragePath(string $relativePath): array
     {
-        return $this->parseFromPath(
-            $this->storageService->getAbsolutePath($relativePath),
+        return $this->temporaryLocalFile->with(
+            $relativePath,
+            fn (string $absolutePath): array => $this->parseFromPath($absolutePath),
         );
     }
 }

--- a/site/src/Marketplace/MessageHandler/ImportInventoryCostPriceHandler.php
+++ b/site/src/Marketplace/MessageHandler/ImportInventoryCostPriceHandler.php
@@ -11,7 +11,7 @@ use App\Marketplace\Inventory\Application\Command\ImportInventoryCostPriceFromFi
 use App\Marketplace\Inventory\Application\ImportInventoryCostPriceFromFileAction;
 use App\Marketplace\Message\ImportInventoryCostPriceMessage;
 use App\Marketplace\Repository\MarketplaceJobLogRepository;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\TemporaryLocalFile;
 use Psr\Log\LoggerInterface;
 use Ramsey\Uuid\Uuid;
 use Symfony\Component\Messenger\Attribute\AsMessageHandler;
@@ -21,7 +21,7 @@ final class ImportInventoryCostPriceHandler
 {
     public function __construct(
         private readonly ImportInventoryCostPriceFromFileAction $action,
-        private readonly StorageService                        $storageService,
+        private readonly TemporaryLocalFile                    $temporaryLocalFile,
         private readonly MarketplaceJobLogRepository           $jobLogRepository,
         private readonly LoggerInterface                       $logger,
     ) {
@@ -45,22 +45,21 @@ final class ImportInventoryCostPriceHandler
         ]);
 
         try {
-            $absolutePath = $this->storageService->getAbsolutePath($message->storagePath);
+            $result = $this->temporaryLocalFile->with(
+                $message->storagePath,
+                function (string $absolutePath) use ($message): array {
+                    $command = new ImportInventoryCostPriceFromFileCommand(
+                        companyId:        $message->companyId,
+                        absoluteFilePath: $absolutePath,
+                        originalFilename: $message->originalFilename,
+                        effectiveFrom:    new \DateTimeImmutable($message->effectiveFrom),
+                        marketplace:      MarketplaceType::from($message->marketplace),
+                        identifierType:   $message->identifierType,
+                    );
 
-            if (!file_exists($absolutePath)) {
-                throw new \RuntimeException('File not found: ' . $absolutePath);
-            }
-
-            $command = new ImportInventoryCostPriceFromFileCommand(
-                companyId:        $message->companyId,
-                absoluteFilePath: $absolutePath,
-                originalFilename: $message->originalFilename,
-                effectiveFrom:    new \DateTimeImmutable($message->effectiveFrom),
-                marketplace:      MarketplaceType::from($message->marketplace),
-                identifierType:   $message->identifierType,
+                    return ($this->action)($command);
+                },
             );
-
-            $result = ($this->action)($command);
 
             // Формируем details из ошибок
             $details = array_map(

--- a/site/src/MarketplaceAnalytics/Controller/Api/DebugReparseMutualSettlementController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/DebugReparseMutualSettlementController.php
@@ -8,7 +8,8 @@ use App\Marketplace\Application\Processor\OzonMutualSettlementProcessor;
 use App\Marketplace\Enum\PipelineStep;
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use App\Shared\Service\ActiveCompanyService;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Shared\Service\Storage\TemporaryLocalFile;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\JsonResponse;
@@ -36,7 +37,8 @@ final class DebugReparseMutualSettlementController extends AbstractController
         private readonly ActiveCompanyService $activeCompanyService,
         private readonly MarketplaceRawDocumentRepository $rawDocumentRepository,
         private readonly OzonMutualSettlementProcessor $processor,
-        private readonly StorageService $storageService,
+        private readonly ObjectStorageInterface $storage,
+        private readonly TemporaryLocalFile $temporaryLocalFile,
         private readonly EntityManagerInterface $em,
     ) {
     }
@@ -61,17 +63,18 @@ final class DebugReparseMutualSettlementController extends AbstractController
             ], 422);
         }
 
-        $absolutePath = $this->storageService->getAbsolutePath($rawData['file_path']);
-
-        if (!file_exists($absolutePath)) {
+        if (!$this->storage->exists($rawData['file_path'])) {
             return $this->json([
                 'success' => false,
-                'error' => 'Файл не найден на диске: ' . $rawData['file_path'],
+                'error' => 'Файл не найден в хранилище: ' . $rawData['file_path'],
             ], 404);
         }
 
         try {
-            $parsed = $this->processor->parse($absolutePath);
+            $parsed = $this->temporaryLocalFile->with(
+                $rawData['file_path'],
+                fn (string $absolutePath): array => $this->processor->parse($absolutePath),
+            );
 
             $rawData['parsed'] = $parsed;
             unset($rawData['parsing_error']);

--- a/site/tests/Unit/Marketplace/Application/Reconciliation/OzonReportParserFacadeStorageTest.php
+++ b/site/tests/Unit/Marketplace/Application/Reconciliation/OzonReportParserFacadeStorageTest.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Marketplace\Application\Reconciliation;
+
+use App\Marketplace\Application\Reconciliation\BaseSignResolverService;
+use App\Marketplace\Application\Reconciliation\OzonReportParserFacade;
+use App\Marketplace\Application\Reconciliation\ReportAggregatorService;
+use App\Marketplace\Application\Reconciliation\RowClassifierService;
+use App\Marketplace\Application\Reconciliation\XlsxReaderService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Shared\Service\Storage\StoredObject;
+use App\Shared\Service\Storage\TemporaryLocalFile;
+use DG\BypassFinals;
+use PHPUnit\Framework\TestCase;
+
+// Коллабораторы фасада — final, нужен BypassFinals для createMock.
+BypassFinals::allowPaths([
+    '*/src/Marketplace/Application/Reconciliation/*.php',
+]);
+
+/**
+ * Регрессия PR 5a (S3-миграция, тип B): parseFromStoragePath читает файл через
+ * объектное хранилище — скачивает во временную локальную копию с сохранением
+ * расширения (.xlsx) и передаёт её ридеру, а не абсолютный путь с диска.
+ */
+final class OzonReportParserFacadeStorageTest extends TestCase
+{
+    public function testParsesFromStorageViaTemporaryLocalXlsxFile(): void
+    {
+        $bytes = 'FAKE-XLSX-'.bin2hex(random_bytes(6));
+
+        $seenPath = null;
+        $reader = $this->createMock(XlsxReaderService::class);
+        $reader->method('read')->willReturnCallback(function (string $path) use ($bytes, &$seenPath): array {
+            $seenPath = $path;
+            self::assertFileExists($path, 'Ридер должен получить реальный локальный файл.');
+            self::assertSame('xlsx', pathinfo($path, \PATHINFO_EXTENSION), 'Временный файл должен сохранить расширение ключа.');
+            self::assertSame($bytes, file_get_contents($path));
+
+            return ['rows' => [], 'period' => '2025-01'];
+        });
+
+        $aggregator = $this->createMock(ReportAggregatorService::class);
+        $aggregator->method('aggregate')->willReturn(['ok' => true]);
+
+        $facade = new OzonReportParserFacade(
+            $reader,
+            $this->createMock(BaseSignResolverService::class),
+            $this->createMock(RowClassifierService::class),
+            $aggregator,
+            new TemporaryLocalFile($this->storageReturning($bytes)),
+        );
+
+        $result = $facade->parseFromStoragePath('marketplace/reconciliation/ozon/2025-01/report.xlsx');
+
+        self::assertSame(['ok' => true], $result);
+        self::assertIsString($seenPath);
+        self::assertFileDoesNotExist($seenPath, 'Временная копия должна быть удалена после парсинга.');
+    }
+
+    private function storageReturning(string $contents): ObjectStorageInterface
+    {
+        return new class($contents) implements ObjectStorageInterface {
+            public function __construct(private readonly string $contents)
+            {
+            }
+
+            public function write(string $path, string $contents): StoredObject
+            {
+                throw new \LogicException('not needed');
+            }
+
+            public function read(string $path): string
+            {
+                return $this->contents;
+            }
+
+            public function readStream(string $path)
+            {
+                $stream = fopen('php://memory', 'r+b');
+                fwrite($stream, $this->contents);
+                rewind($stream);
+
+                return $stream;
+            }
+
+            public function exists(string $path): bool
+            {
+                return true;
+            }
+
+            public function delete(string $path): void
+            {
+            }
+        };
+    }
+}


### PR DESCRIPTION
Пятый PR (часть a) S3-миграции. От чистого master. Разбивка PR 5 на 5a (Marketplace/Catalog) и 5b (MarketplaceAds + тяжёлые тесты).

## Что тут
5 парсер-сайтов: `getAbsolutePath()` + прямой парсинг → `TemporaryLocalFile::with()` (скачивание во временную копию **с расширением ключа** → парсер → авто-очистка). Драйвер `local`, файлы физически там же.

| Сайт | Изменение |
|---|---|
| `Catalog\ImportProductsFromXlsAction` | read → `with()` |
| `Marketplace\OzonReportParserFacade` | `parseFromStoragePath` → `with()` |
| `Marketplace\ImportInventoryCostPriceHandler` | вызов action обёрнут (temp живёт весь импорт) |
| `MarketplaceAnalytics\DebugReparseMutualSettlementController` | `exists()`→404 + `with()` |
| `Marketplace\LoadMutualSettlementAction` | **write+read**: `file_put_contents` → `write()`; `parse` → `with()` |

MarketplaceAds (тип B + 2 storeBytes-сайта + их тесты) — PR 5b; download-контроллеры — PR 6.

## Проверка
- `docker compose run --rm -T site-php-cli php bin/phpunit --filter OzonReportParserFacadeStorageTest` — storage→temp `.xlsx`→reader→cleanup (6 assertions)
- Регрессия unit Reconciliation/Catalog 14/14; `lint:container` OK

## Заметки ревьюеру
- **Money-adjacent** (парсеры сверок/себестоимости): логика парсинга/агрегации не менялась, только источник файла.
- `LoadMutualSettlementAction` — единственный write+read; ключ записи и чтения один.
- `ImportInventoryCostPriceHandler`: убран `file_exists`-чек; отсутствие файла → `ObjectStorageException` из `readStream` → тот же catch (эквивалентно).
- CS: пред-существующий долг выравнивания (master даёт те же 5 of 5); новый тест чист.

Stage Report: `docs/tasks/s3-migration/stages/stage-5a.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)