### PR TITLE
feat(storage): PR 5b — MarketplaceAds через ObjectStorageInterface (тип B)

### DIFF
--- a/docs/tasks/s3-migration/stages/stage-5b.md
+++ b/docs/tasks/s3-migration/stages/stage-5b.md
@@ -1,0 +1,66 @@
+## Stage 5b (PR 5b): Тип B — MarketplaceAds (Extract + storeBytes-сайты) — DONE
+
+**Риск:** 🟡 MEDIUM (Ozon ad-report flow + тяжёлые тесты)
+**Следующее действие:** continue autonomously (PR 6), сначала PR 5b на ревью/мерж
+**Ветка:** от чистого master
+
+### Что сделано
+3 сайта MarketplaceAds переведены на объектное хранилище:
+
+| Сайт | Тип | Изменение |
+|---|---|---|
+| `ExtractBatchesToRawDocumentsAction::extractCsvsFromBatch` | read (zip/csv) | `getAbsolutePath`+`ZipArchive` → `TemporaryLocalFile::with()` (dispatch zip/csv внутри closure; `extractCsvsFromZip` не менялся) |
+| `DownloadOzonAdReportHandler` | storeBytes-write | `storeBytes($body,$path)` → `write($path,$body)`; `fileHash = hash('sha256',$body)` на месте |
+| `AdBatchPollerCommand` | storeBytes-write | то же + лог + докблок |
+
+Тип B завершён (PR 5a + 5b). Единственный оставшийся `getAbsolutePath` вне Storage —
+`DebugDownloadRawDocumentController` (тип A) → **PR 6**.
+
+### Тесты
+- **Unit (обновлены — конструируют классы напрямую):**
+  - `DownloadOzonAdReportHandlerTest`, `AdBatchPollerCommandTest`: мок `StorageService`
+    → `ObjectStorageInterface`; `storeBytes(array)` → `write`→`StoredObject`
+    (**порядок аргументов инвертирован**: `write(path, contents)`); ассерты `fileHash`
+    → `hash('sha256', $body)` (считается на месте, не из мока).
+  - `ExtractBatchesToRawDocumentsActionTest`: `new StorageService($tmp)` →
+    `new TemporaryLocalFile(new LocalObjectStorage(new StorageService($tmp)))` (файловый
+    setup через tmpDir сохранён); сообщение missing-file `Batch file missing on disk`
+    → `Failed to open object` (теперь `ObjectStorageException` из `readStream`).
+- **Integration — без изменений:** `AdBatchPollerCommandTest`, `ExtractBatchesControllerTest`
+  мокают/используют `StorageService` через контейнер; реальный `LocalObjectStorage`
+  (в test = `ObjectStorageInterface`) **делегирует** в него → перехват `storeBytes`/
+  `getAbsolutePath` сохранён на уровень глубже. 24/24 зелёные без правок.
+
+### Затронутые файлы
+- `src/MarketplaceAds/Application/ExtractBatchesToRawDocumentsAction.php` — modified
+- `src/MarketplaceAds/MessageHandler/DownloadOzonAdReportHandler.php` — modified
+- `src/MarketplaceAds/Command/AdBatchPollerCommand.php` — modified
+- `tests/Unit/MarketplaceAds/Application/ExtractBatchesToRawDocumentsActionTest.php` — modified
+- `tests/Unit/MarketplaceAds/MessageHandler/DownloadOzonAdReportHandlerTest.php` — modified
+- `tests/Unit/MarketplaceAds/Command/AdBatchPollerCommandTest.php` — modified
+
+### Self-review
+- [x] Scope compliance — только 3 MarketplaceAds-сайта + их тесты
+- [x] Patterns / naming — `with()` для read, `write()` для storeBytes, hash на месте (как cash/PR3)
+- [x] Forbidden actions — none
+- [x] Security — companyId в ключах сохранён
+- [x] Tests green — MarketplaceAds unit 304/304, integration 24/24
+- [x] DI — `lint:container` OK (3 конструктора)
+- [~] CS-Fixer — пред-существующий долг (master = те же 3 of 6); мои строки чистые
+- [N/A] PHPStan — в проекте не установлен
+
+### Команды для проверки
+- `docker compose run --rm -T site-php-cli php bin/phpunit --testsuite unit --filter MarketplaceAds`
+- `docker compose run --rm -T site-php-cli php bin/phpunit --testsuite integration --filter "ExtractBatchesControllerTest|AdBatchPollerCommandTest"`
+
+### Риски / на что обратить внимание ревьюеру
+- `extractCsvsFromBatch`: убран `file_exists`-чек; отсутствие файла теперь
+  `ObjectStorageException` (extends RuntimeException) с сообщением «Failed to open object»
+  вместо «Batch file missing on disk». Тип исключения сохранён, сообщение изменилось.
+- Ozon ad-report zip'ы могут быть крупными — `TemporaryLocalFile` буферизует в `/tmp`;
+  расширение `.zip` сохраняется, `ZipArchive` открывает temp корректно.
+- Интеграционные тесты теперь косвенно гоняют реальную цепочку хранилища
+  (LocalObjectStorage→мок StorageService) — покрытие не хуже, чем прямой мок.
+
+### Открытые вопросы
+- нет

--- a/site/src/MarketplaceAds/Application/ExtractBatchesToRawDocumentsAction.php
+++ b/site/src/MarketplaceAds/Application/ExtractBatchesToRawDocumentsAction.php
@@ -10,7 +10,7 @@ use App\MarketplaceAds\Entity\AdScheduledBatch;
 use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
 use App\MarketplaceAds\Repository\AdScheduledBatchRepository;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\TemporaryLocalFile;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -40,7 +40,7 @@ final readonly class ExtractBatchesToRawDocumentsAction
     public function __construct(
         private AdScheduledBatchRepository $batchRepo,
         private AdRawDocumentRepository $rawDocRepo,
-        private StorageService $storageService,
+        private TemporaryLocalFile $temporaryLocalFile,
         private EntityManagerInterface $em,
         private MessageBusInterface $messageBus,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
@@ -278,28 +278,28 @@ final readonly class ExtractBatchesToRawDocumentsAction
             throw new \RuntimeException('Batch has no storage_path');
         }
 
-        $absolutePath = $this->storageService->getAbsolutePath($storagePath);
-        if (!file_exists($absolutePath)) {
-            throw new \RuntimeException('Batch file missing on disk: '.$absolutePath);
-        }
+        return $this->temporaryLocalFile->with(
+            $storagePath,
+            function (string $absolutePath) use ($storagePath): array {
+                $extension = strtolower(pathinfo($storagePath, \PATHINFO_EXTENSION));
 
-        $extension = strtolower(pathinfo($storagePath, \PATHINFO_EXTENSION));
+                if ('csv' === $extension) {
+                    $filename = basename($storagePath);
+                    $content = file_get_contents($absolutePath);
+                    if (false === $content) {
+                        throw new \RuntimeException('Cannot read csv file: '.$absolutePath);
+                    }
 
-        if ('csv' === $extension) {
-            $filename = basename($storagePath);
-            $content = file_get_contents($absolutePath);
-            if (false === $content) {
-                throw new \RuntimeException('Cannot read csv file: '.$absolutePath);
-            }
+                    return [$filename => $content];
+                }
 
-            return [$filename => $content];
-        }
+                if ('zip' === $extension) {
+                    return $this->extractCsvsFromZip($absolutePath);
+                }
 
-        if ('zip' === $extension) {
-            return $this->extractCsvsFromZip($absolutePath);
-        }
-
-        throw new \RuntimeException('Unknown batch file extension: '.$extension);
+                throw new \RuntimeException('Unknown batch file extension: '.$extension);
+            },
+        );
     }
 
     /**

--- a/site/src/MarketplaceAds/Command/AdBatchPollerCommand.php
+++ b/site/src/MarketplaceAds/Command/AdBatchPollerCommand.php
@@ -11,7 +11,7 @@ use App\MarketplaceAds\Enum\AdScheduledBatchState;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Repository\AdScheduledBatchRepository;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\Console\Attribute\AsCommand;
@@ -29,7 +29,7 @@ use Symfony\Component\DependencyInjection\Attribute\Autowire;
  *     возвращает normalized state (uppercase).
  *  2) по state:
  *      - `OK` / `READY`  → {@see OzonAdClient::fetchReportContent()} → сохранить
- *        файл через {@see StorageService::storeBytes()} → batch в OK;
+ *        файл через {@see ObjectStorageInterface::write()} → batch в OK;
  *      - `ERROR` / `CANCELLED` / `NOT_FOUND` → batch в FAILED с причиной;
  *      - `NOT_STARTED` / `IN_PROGRESS` → проверяется возраст:
  *          - moложе {@see self::MAX_AGE_BEFORE_ABANDON_HOURS}ч — без изменений
@@ -78,7 +78,7 @@ final class AdBatchPollerCommand extends Command
     public function __construct(
         private readonly OzonAdClient $ozonClient,
         private readonly AdScheduledBatchRepository $batchRepo,
-        private readonly StorageService $storageService,
+        private readonly ObjectStorageInterface $storage,
         private readonly EntityManagerInterface $em,
         private readonly ExtractBatchesToRawDocumentsAction $extractAction,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
@@ -309,12 +309,12 @@ final class AdBatchPollerCommand extends Command
             $extension,
         );
 
-        $stored = $this->storageService->storeBytes($body, $relativePath);
+        $stored = $this->storage->write($relativePath, $body);
 
         $batch->setState(AdScheduledBatchState::OK);
-        $batch->setStoragePath((string) $stored['storagePath']);
-        $batch->setFileHash((string) $stored['fileHash']);
-        $batch->setFileSize((int) $stored['sizeBytes']);
+        $batch->setStoragePath($stored->path);
+        $batch->setFileHash(hash('sha256', $body));
+        $batch->setFileSize($stored->byteSize);
         $batch->setFinishedAt(new \DateTimeImmutable('now', new \DateTimeZone('UTC')));
 
         $this->em->flush();
@@ -323,8 +323,8 @@ final class AdBatchPollerCommand extends Command
             'batchId' => $batch->getId(),
             'companyId' => $companyId,
             'ozonUuid' => $uuid,
-            'storagePath' => $stored['storagePath'],
-            'fileSize' => $stored['sizeBytes'],
+            'storagePath' => $stored->path,
+            'fileSize' => $stored->byteSize,
             'extension' => $extension,
         ]);
 

--- a/site/src/MarketplaceAds/MessageHandler/DownloadOzonAdReportHandler.php
+++ b/site/src/MarketplaceAds/MessageHandler/DownloadOzonAdReportHandler.php
@@ -14,7 +14,7 @@ use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Message\DownloadOzonAdReportMessage;
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
 use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use Doctrine\ORM\EntityManagerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Component\DependencyInjection\Attribute\Autowire;
@@ -57,7 +57,7 @@ final class DownloadOzonAdReportHandler
         private readonly AdRawDocumentRepository $rawRepo,
         private readonly OzonAdClient $client,
         private readonly EntityManagerInterface $em,
-        private readonly StorageService $storageService,
+        private readonly ObjectStorageInterface $storage,
         private readonly AdLoadJobFinalizer $finalizer,
         #[Autowire(service: 'monolog.logger.marketplace_ads')]
         private readonly LoggerInterface $logger,
@@ -141,10 +141,10 @@ final class DownloadOzonAdReportHandler
             $extension,
         );
 
-        $stored = $this->storageService->storeBytes($body, $relativePath);
-        $storagePath = (string) $stored['storagePath'];
-        $fileHash = (string) $stored['fileHash'];
-        $sizeBytes = (int) $stored['sizeBytes'];
+        $stored = $this->storage->write($relativePath, $body);
+        $storagePath = $stored->path;
+        $fileHash = hash('sha256', $body);
+        $sizeBytes = $stored->byteSize;
 
         // Для каждого дня pending-диапазона — upsert AdRawDocument. Один файл
         // на диске, N документов в БД (по дню). Парсинг отключён, поэтому

--- a/site/tests/Unit/MarketplaceAds/Application/ExtractBatchesToRawDocumentsActionTest.php
+++ b/site/tests/Unit/MarketplaceAds/Application/ExtractBatchesToRawDocumentsActionTest.php
@@ -11,7 +11,9 @@ use App\MarketplaceAds\Enum\AdScheduledBatchState;
 use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
 use App\MarketplaceAds\Repository\AdScheduledBatchRepository;
+use App\Shared\Service\Storage\LocalObjectStorage;
 use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\TemporaryLocalFile;
 use App\Tests\Builders\MarketplaceAds\AdScheduledBatchBuilder;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\TestCase;
@@ -47,7 +49,7 @@ final class ExtractBatchesToRawDocumentsActionTest extends TestCase
         $this->action = new ExtractBatchesToRawDocumentsAction(
             $this->createMock(AdScheduledBatchRepository::class),
             $this->createMock(AdRawDocumentRepository::class),
-            new StorageService($this->tmpDir),
+            new TemporaryLocalFile(new LocalObjectStorage(new StorageService($this->tmpDir))),
             $this->createMock(EntityManagerInterface::class),
             $this->createMock(MessageBusInterface::class),
             new NullLogger(),
@@ -161,8 +163,10 @@ final class ExtractBatchesToRawDocumentsActionTest extends TestCase
             ->withStorage('marketplace-ads/nowhere/ghost.csv', 'hash', 10)
             ->build();
 
+        // Файл отсутствует в хранилище → readStream внутри TemporaryLocalFile
+        // бросает ObjectStorageException (extends RuntimeException).
         $this->expectException(\RuntimeException::class);
-        $this->expectExceptionMessageMatches('/Batch file missing on disk/');
+        $this->expectExceptionMessageMatches('/Failed to open object/');
 
         $this->action->extractCsvsFromBatch($batch);
     }
@@ -215,7 +219,7 @@ final class ExtractBatchesToRawDocumentsActionTest extends TestCase
         $action = new ExtractBatchesToRawDocumentsAction(
             $this->createMock(AdScheduledBatchRepository::class),
             $rawDocRepo,
-            new StorageService($this->tmpDir),
+            new TemporaryLocalFile(new LocalObjectStorage(new StorageService($this->tmpDir))),
             $em,
             $messageBus,
             new NullLogger(),
@@ -264,7 +268,7 @@ final class ExtractBatchesToRawDocumentsActionTest extends TestCase
         $action = new ExtractBatchesToRawDocumentsAction(
             $this->createMock(AdScheduledBatchRepository::class),
             $rawDocRepo,
-            new StorageService($this->tmpDir),
+            new TemporaryLocalFile(new LocalObjectStorage(new StorageService($this->tmpDir))),
             $em,
             $messageBus,
             new NullLogger(),
@@ -310,7 +314,7 @@ final class ExtractBatchesToRawDocumentsActionTest extends TestCase
         $action = new ExtractBatchesToRawDocumentsAction(
             $this->createMock(AdScheduledBatchRepository::class),
             $rawDocRepo,
-            new StorageService($this->tmpDir),
+            new TemporaryLocalFile(new LocalObjectStorage(new StorageService($this->tmpDir))),
             $em,
             $messageBus,
             new NullLogger(),
@@ -388,7 +392,7 @@ final class ExtractBatchesToRawDocumentsActionTest extends TestCase
         $action = new ExtractBatchesToRawDocumentsAction(
             $this->createMock(AdScheduledBatchRepository::class),
             $rawDocRepo,
-            new StorageService($this->tmpDir),
+            new TemporaryLocalFile(new LocalObjectStorage(new StorageService($this->tmpDir))),
             $em,
             $messageBus,
             new NullLogger(),
@@ -421,7 +425,7 @@ final class ExtractBatchesToRawDocumentsActionTest extends TestCase
         $action = new ExtractBatchesToRawDocumentsAction(
             $this->createMock(AdScheduledBatchRepository::class),
             $rawDocRepo,
-            new StorageService($this->tmpDir),
+            new TemporaryLocalFile(new LocalObjectStorage(new StorageService($this->tmpDir))),
             $em,
             $messageBus,
             new NullLogger(),

--- a/site/tests/Unit/MarketplaceAds/Command/AdBatchPollerCommandTest.php
+++ b/site/tests/Unit/MarketplaceAds/Command/AdBatchPollerCommandTest.php
@@ -11,7 +11,8 @@ use App\MarketplaceAds\Enum\AdScheduledBatchState;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonAdClient;
 use App\MarketplaceAds\Infrastructure\Api\Ozon\OzonPermanentApiException;
 use App\MarketplaceAds\Repository\AdScheduledBatchRepository;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Shared\Service\Storage\StoredObject;
 use App\Tests\Builders\MarketplaceAds\AdScheduledBatchBuilder;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -38,8 +39,8 @@ final class AdBatchPollerCommandTest extends TestCase
     private OzonAdClient $ozonClient;
     /** @var AdScheduledBatchRepository&MockObject */
     private AdScheduledBatchRepository $batchRepo;
-    /** @var StorageService&MockObject */
-    private StorageService $storage;
+    /** @var ObjectStorageInterface&MockObject */
+    private ObjectStorageInterface $storage;
     /** @var EntityManagerInterface&MockObject */
     private EntityManagerInterface $em;
     /** @var ExtractBatchesToRawDocumentsAction&MockObject */
@@ -51,7 +52,7 @@ final class AdBatchPollerCommandTest extends TestCase
     {
         $this->ozonClient = $this->createMock(OzonAdClient::class);
         $this->batchRepo = $this->createMock(AdScheduledBatchRepository::class);
-        $this->storage = $this->createMock(StorageService::class);
+        $this->storage = $this->createMock(ObjectStorageInterface::class);
         $this->em = $this->createMock(EntityManagerInterface::class);
         $this->extractAction = $this->createMock(ExtractBatchesToRawDocumentsAction::class);
 
@@ -90,18 +91,14 @@ final class AdBatchPollerCommandTest extends TestCase
             ->method('fetchReportContent')
             ->willReturn(['body' => 'a,b,c', 'contentType' => 'text/csv']);
 
+        $expectedPath = sprintf('marketplace-ads/%s/%s.csv', $batch->getCompanyId(), (string) $batch->getOzonUuid());
         $this->storage->expects(self::once())
-            ->method('storeBytes')
+            ->method('write')
             ->with(
+                self::stringContains($expectedPath),
                 'a,b,c',
-                self::stringContains(sprintf('marketplace-ads/%s/%s.csv', $batch->getCompanyId(), (string) $batch->getOzonUuid())),
             )
-            ->willReturn([
-                'storagePath' => sprintf('marketplace-ads/%s/%s.csv', $batch->getCompanyId(), (string) $batch->getOzonUuid()),
-                'fileHash' => 'abc123',
-                'sizeBytes' => 5,
-                'mimeType' => null,
-            ]);
+            ->willReturn(new StoredObject($expectedPath, 5));
 
         $this->em->expects(self::once())->method('flush');
 
@@ -115,7 +112,7 @@ final class AdBatchPollerCommandTest extends TestCase
         self::assertSame(0, $tester->execute([]));
 
         self::assertSame(AdScheduledBatchState::OK, $batch->getState());
-        self::assertSame('abc123', $batch->getFileHash());
+        self::assertSame(hash('sha256', 'a,b,c'), $batch->getFileHash());
         self::assertSame(5, $batch->getFileSize());
         self::assertNotNull($batch->getFinishedAt());
         self::assertNull($batch->getLastError());
@@ -131,12 +128,10 @@ final class AdBatchPollerCommandTest extends TestCase
         $this->ozonClient->method('fetchReportContent')
             ->willReturn(['body' => 'a,b,c', 'contentType' => 'text/csv']);
 
-        $this->storage->method('storeBytes')->willReturn([
-            'storagePath' => sprintf('marketplace-ads/%s/%s.csv', $batch->getCompanyId(), (string) $batch->getOzonUuid()),
-            'fileHash' => 'abc123',
-            'sizeBytes' => 5,
-            'mimeType' => null,
-        ]);
+        $this->storage->method('write')->willReturn(new StoredObject(
+            sprintf('marketplace-ads/%s/%s.csv', $batch->getCompanyId(), (string) $batch->getOzonUuid()),
+            5,
+        ));
 
         // Auto-extract падает — это НЕ должно перевести batch в FAILED.
         $this->extractAction->expects(self::once())
@@ -160,7 +155,7 @@ final class AdBatchPollerCommandTest extends TestCase
             ->willReturn(['state' => 'ERROR', 'raw' => ['state' => 'ERROR']]);
 
         $this->ozonClient->expects(self::never())->method('fetchReportContent');
-        $this->storage->expects(self::never())->method('storeBytes');
+        $this->storage->expects(self::never())->method('write');
         $this->em->expects(self::once())->method('flush');
 
         $tester = new CommandTester($this->command);
@@ -202,7 +197,7 @@ final class AdBatchPollerCommandTest extends TestCase
             ->method('fetchReportContent')
             ->willThrowException(new OzonPermanentApiException('403 revoked mid-download'));
 
-        $this->storage->expects(self::never())->method('storeBytes');
+        $this->storage->expects(self::never())->method('write');
         $this->em->expects(self::once())->method('flush');
 
         $tester = new CommandTester($this->command);
@@ -241,7 +236,7 @@ final class AdBatchPollerCommandTest extends TestCase
 
         // Не трогаем batch — ни flush, ни mutation.
         $this->ozonClient->expects(self::never())->method('fetchReportContent');
-        $this->storage->expects(self::never())->method('storeBytes');
+        $this->storage->expects(self::never())->method('write');
         $this->em->expects(self::never())->method('flush');
 
         $tester = new CommandTester($this->command);

--- a/site/tests/Unit/MarketplaceAds/MessageHandler/DownloadOzonAdReportHandlerTest.php
+++ b/site/tests/Unit/MarketplaceAds/MessageHandler/DownloadOzonAdReportHandlerTest.php
@@ -16,7 +16,8 @@ use App\MarketplaceAds\Message\DownloadOzonAdReportMessage;
 use App\MarketplaceAds\MessageHandler\DownloadOzonAdReportHandler;
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
 use App\MarketplaceAds\Repository\OzonAdPendingReportRepository;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Shared\Service\Storage\StoredObject;
 use DG\BypassFinals;
 use Doctrine\ORM\EntityManagerInterface;
 use PHPUnit\Framework\MockObject\MockObject;
@@ -24,10 +25,8 @@ use PHPUnit\Framework\TestCase;
 use Psr\Log\NullLogger;
 use Ramsey\Uuid\Uuid;
 
-// StorageService — final class, нужен BypassFinals для createMock.
 // AdLoadJobFinalizer — final readonly, нужен BypassFinals для createMock.
 BypassFinals::allowPaths([
-    '*/src/Shared/Service/Storage/StorageService.php',
     '*/src/MarketplaceAds/Application/Service/AdLoadJobFinalizer.php',
 ]);
 
@@ -61,8 +60,8 @@ final class DownloadOzonAdReportHandlerTest extends TestCase
     private OzonAdClient $client;
     /** @var EntityManagerInterface&MockObject */
     private EntityManagerInterface $em;
-    /** @var StorageService&MockObject */
-    private StorageService $storage;
+    /** @var ObjectStorageInterface&MockObject */
+    private ObjectStorageInterface $storage;
     /** @var AdLoadJobFinalizer&MockObject */
     private AdLoadJobFinalizer $finalizer;
 
@@ -72,7 +71,7 @@ final class DownloadOzonAdReportHandlerTest extends TestCase
         $this->rawRepo = $this->createMock(AdRawDocumentRepository::class);
         $this->client = $this->createMock(OzonAdClient::class);
         $this->em = $this->createMock(EntityManagerInterface::class);
-        $this->storage = $this->createMock(StorageService::class);
+        $this->storage = $this->createMock(ObjectStorageInterface::class);
         $this->finalizer = $this->createMock(AdLoadJobFinalizer::class);
     }
 
@@ -86,7 +85,7 @@ final class DownloadOzonAdReportHandlerTest extends TestCase
         $this->client->expects(self::never())->method('fetchReportContent');
         $this->pendingRepo->expects(self::never())->method('markFinalized');
         $this->em->expects(self::never())->method('flush');
-        $this->storage->expects(self::never())->method('storeBytes');
+        $this->storage->expects(self::never())->method('write');
 
         $this->makeHandler()(new DownloadOzonAdReportMessage(
             companyId: self::COMPANY_ID,
@@ -103,7 +102,7 @@ final class DownloadOzonAdReportHandlerTest extends TestCase
         $this->client->expects(self::never())->method('fetchReportContent');
         $this->pendingRepo->expects(self::never())->method('markFinalized');
         $this->em->expects(self::never())->method('flush');
-        $this->storage->expects(self::never())->method('storeBytes');
+        $this->storage->expects(self::never())->method('write');
 
         $this->makeHandler()(new DownloadOzonAdReportMessage(
             companyId: self::COMPANY_ID,
@@ -131,7 +130,7 @@ final class DownloadOzonAdReportHandlerTest extends TestCase
             ->willReturn(1);
 
         $this->em->expects(self::never())->method('flush');
-        $this->storage->expects(self::never())->method('storeBytes');
+        $this->storage->expects(self::never())->method('write');
 
         $this->expectException(\Symfony\Component\Messenger\Exception\UnrecoverableMessageHandlingException::class);
         $this->expectExceptionMessage('Ozon permanent failure');
@@ -152,7 +151,7 @@ final class DownloadOzonAdReportHandlerTest extends TestCase
 
         $this->pendingRepo->expects(self::never())->method('markFinalized');
         $this->em->expects(self::never())->method('flush');
-        $this->storage->expects(self::never())->method('storeBytes');
+        $this->storage->expects(self::never())->method('write');
 
         $this->expectException(\RuntimeException::class);
         $this->expectExceptionMessage('network timeout');
@@ -188,14 +187,9 @@ final class DownloadOzonAdReportHandlerTest extends TestCase
 
         $expectedPath = sprintf('marketplace-ads/%s/%s.csv', self::COMPANY_ID, self::OZON_UUID);
         $this->storage->expects(self::once())
-            ->method('storeBytes')
-            ->with($csvBody, $expectedPath)
-            ->willReturn([
-                'storagePath' => $expectedPath,
-                'fileHash' => 'sha256:deadbeef',
-                'sizeBytes' => \strlen($csvBody),
-                'mimeType' => 'text/csv',
-            ]);
+            ->method('write')
+            ->with($expectedPath, $csvBody)
+            ->willReturn(new StoredObject($expectedPath, \strlen($csvBody)));
 
         // Строгий порядок: flush → markFinalized(OK).
         $trace = [];
@@ -225,7 +219,7 @@ final class DownloadOzonAdReportHandlerTest extends TestCase
             self::assertSame('{}', $doc->getRawPayload(), 'raw_payload = "{}" — контент на диске, не в БД');
             self::assertSame(AdRawDocumentStatus::DRAFT, $doc->getStatus());
             self::assertSame($expectedPath, $doc->getStoragePath());
-            self::assertSame('sha256:deadbeef', $doc->getFileHash());
+            self::assertSame(hash('sha256', $csvBody), $doc->getFileHash());
             self::assertSame(\strlen($csvBody), $doc->getFileSizeBytes());
         }
 
@@ -251,14 +245,9 @@ final class DownloadOzonAdReportHandlerTest extends TestCase
 
         $expectedPath = sprintf('marketplace-ads/%s/%s.zip', self::COMPANY_ID, self::OZON_UUID);
         $this->storage->expects(self::once())
-            ->method('storeBytes')
-            ->with(self::anything(), $expectedPath)
-            ->willReturn([
-                'storagePath' => $expectedPath,
-                'fileHash' => 'h',
-                'sizeBytes' => 15,
-                'mimeType' => 'application/zip',
-            ]);
+            ->method('write')
+            ->with($expectedPath, self::anything())
+            ->willReturn(new StoredObject($expectedPath, 15));
 
         $this->pendingRepo->method('markFinalized')->willReturn(1);
 
@@ -285,14 +274,9 @@ final class DownloadOzonAdReportHandlerTest extends TestCase
 
         $expectedPath = sprintf('marketplace-ads/%s/%s.zip', self::COMPANY_ID, self::OZON_UUID);
         $this->storage->expects(self::once())
-            ->method('storeBytes')
-            ->with($zipBody, $expectedPath)
-            ->willReturn([
-                'storagePath' => $expectedPath,
-                'fileHash' => 'h',
-                'sizeBytes' => \strlen($zipBody),
-                'mimeType' => 'application/zip',
-            ]);
+            ->method('write')
+            ->with($expectedPath, $zipBody)
+            ->willReturn(new StoredObject($expectedPath, \strlen($zipBody)));
 
         $this->pendingRepo->method('markFinalized')->willReturn(1);
 
@@ -316,14 +300,9 @@ final class DownloadOzonAdReportHandlerTest extends TestCase
 
         $expectedPath = sprintf('marketplace-ads/%s/%s.csv', self::COMPANY_ID, self::OZON_UUID);
         $this->storage->expects(self::once())
-            ->method('storeBytes')
-            ->with(self::anything(), $expectedPath)
-            ->willReturn([
-                'storagePath' => $expectedPath,
-                'fileHash' => 'h',
-                'sizeBytes' => 14,
-                'mimeType' => 'text/plain',
-            ]);
+            ->method('write')
+            ->with($expectedPath, self::anything())
+            ->willReturn(new StoredObject($expectedPath, 14));
 
         $this->pendingRepo->method('markFinalized')->willReturn(1);
 
@@ -360,12 +339,7 @@ final class DownloadOzonAdReportHandlerTest extends TestCase
             'body' => 'body',
             'contentType' => 'text/csv',
         ]);
-        $this->storage->method('storeBytes')->willReturn([
-            'storagePath' => 'path',
-            'fileHash' => 'h',
-            'sizeBytes' => 4,
-            'mimeType' => 'text/csv',
-        ]);
+        $this->storage->method('write')->willReturn(new StoredObject('path', 4));
         $this->pendingRepo->method('markFinalized')->willReturn(1);
 
         $this->makeHandler()(new DownloadOzonAdReportMessage(


### PR DESCRIPTION
Пятый PR (часть b) S3-миграции. **Завершает тип B.** От чистого master.

## Что тут
3 сайта MarketplaceAds:
| Сайт | Изменение |
|---|---|
| `ExtractBatchesToRawDocumentsAction::extractCsvsFromBatch` | `getAbsolutePath`+`ZipArchive` → `TemporaryLocalFile::with()` (zip/csv dispatch внутри closure) |
| `DownloadOzonAdReportHandler` | `storeBytes` → `write`, `fileHash` на месте |
| `AdBatchPollerCommand` | то же + лог/докблок |

Драйвер `local`, файлы физически там же. Оставшийся `getAbsolutePath` (`DebugDownloadRawDocumentController`, тип A) — PR 6.

## Тесты
- **Unit обновлены** (конструируют классы напрямую): мок `StorageService` → `ObjectStorageInterface`; `storeBytes(array)` → `write`→`StoredObject` (**порядок аргументов инвертирован**); `fileHash`-ассерты → `hash('sha256', $body)`. Extract-тест оборачивает реальный `StorageService($tmp)` в `LocalObjectStorage`+`TemporaryLocalFile` (файловый setup сохранён); missing-file сообщение → `Failed to open object`.
- **Integration без правок**: мокают на уровне `StorageService`, реальный `LocalObjectStorage` делегирует туда → перехват сохранён на слой глубже. 24/24 ✓

## Проверка
- `--testsuite unit --filter MarketplaceAds` — 304/304
- `--testsuite integration --filter "ExtractBatchesControllerTest|AdBatchPollerCommandTest"` — ✓
- `lint:container` OK; CS пред-существующий (master = 3 of 6)

## Заметки ревьюеру
- `extractCsvsFromBatch`: убран `file_exists`; отсутствие файла → `ObjectStorageException` (extends RuntimeException), сообщение изменилось (тип сохранён).
- Ozon zip'ы крупные → буфер в `/tmp`; расширение `.zip` сохраняется для `ZipArchive`.

Stage Report: `docs/tasks/s3-migration/stages/stage-5b.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)