### PR TITLE
feat(storage): PR 6 — download-контроллеры → readStream/StreamedResponse (тип A)

### DIFF
--- a/docs/tasks/s3-migration/stages/stage-6.md
+++ b/docs/tasks/s3-migration/stages/stage-6.md
@@ -11,8 +11,8 @@
 
 | Контроллер | Content-Type |
 |---|---|
-| `MarketplaceAds\AdRawDocumentDownloadController` | `application/octet-stream` (было — авто-guess BinaryFileResponse) |
-| `MarketplaceAds\AdScheduledBatchDownloadController` | `application/octet-stream` |
+| `MarketplaceAds\AdRawDocumentDownloadController` | `application/octet-stream` (было — авто-guess BinaryFileResponse) + `Content-Length` из `getFileSizeBytes()` |
+| `MarketplaceAds\AdScheduledBatchDownloadController` | `application/octet-stream` + `Content-Length` из `getFileSize()` |
 | `MarketplaceAds\Api\Admin\DownloadBronzeController` | сохранён (`application/zip` / `text/csv`) + Content-Length |
 | `MarketplaceAnalytics\Api\DebugDownloadRawDocumentController` | сохранён (`rawData.content_type`); base64-ветка (legacy) не тронута |
 

--- a/docs/tasks/s3-migration/stages/stage-6.md
+++ b/docs/tasks/s3-migration/stages/stage-6.md
@@ -1,0 +1,59 @@
+## Stage 6 (PR 6): Тип A — download-контроллеры → readStream/StreamedResponse — DONE
+
+**Риск:** 🟢 LOW → 🟡 MEDIUM (публичные download-эндпоинты)
+**Следующее действие:** continue autonomously (PR 7), сначала PR 6 на ревью/мерж
+**Ветка:** от чистого master
+
+### Что сделано (последние getAbsolutePath)
+4 download-контроллера: `getAbsolutePath()` + `BinaryFileResponse`/`readfile` →
+`ObjectStorageInterface::readStream()` + `StreamedResponse` (`fpassthru` + `fclose`).
+Проверка наличия: `getAbsolutePath`+`is_file`/`file_exists` → `$storage->exists()` → 404.
+
+| Контроллер | Content-Type |
+|---|---|
+| `MarketplaceAds\AdRawDocumentDownloadController` | `application/octet-stream` (было — авто-guess BinaryFileResponse) |
+| `MarketplaceAds\AdScheduledBatchDownloadController` | `application/octet-stream` |
+| `MarketplaceAds\Api\Admin\DownloadBronzeController` | сохранён (`application/zip` / `text/csv`) + Content-Length |
+| `MarketplaceAnalytics\Api\DebugDownloadRawDocumentController` | сохранён (`rawData.content_type`); base64-ветка (legacy) не тронута |
+
+**Проксирование через приложение сохранено** (по плану: без presigned URL, бакет
+приватный, авторизация/IDOR в контроллере).
+
+### 🎯 Веха: S3-гейт по коду закрыт
+`grep -rn "getAbsolutePath" src/` вне `Shared/Service/Storage/` — **пусто**. Все
+читатели переведены на `read`/`readStream`/`TemporaryLocalFile`. Одно из предусловий
+флипа на S3 (PR 8) выполнено.
+
+### Затронутые файлы
+- `src/MarketplaceAds/Controller/AdRawDocumentDownloadController.php` — modified
+- `src/MarketplaceAds/Controller/AdScheduledBatchDownloadController.php` — modified
+- `src/MarketplaceAds/Controller/Api/Admin/DownloadBronzeController.php` — modified
+- `src/MarketplaceAnalytics/Controller/Api/DebugDownloadRawDocumentController.php` — modified
+- `tests/Integration/MarketplaceAds/Controller/AdRawDocumentDownloadControllerTest.php` — modified (assert StreamedResponse)
+
+### Self-review
+- [x] Scope compliance — только 4 download-контроллера (тип A)
+- [x] Patterns / naming — единый `readStream`+`StreamedResponse`+`fpassthru`/`fclose`
+- [x] Forbidden actions — none
+- [x] Security — IDOR сохранён (repo findByIdAndCompany / companyId-проверка); bronze — super-admin (IDOR намеренно off, как было); проксирование, бакет не публичный
+- [x] Tests green — download integration 14/14 (+ assert тип ответа `StreamedResponse`)
+- [x] DI — `lint:container` OK (4 конструктора)
+- [x] CS-Fixer — чисто (0 of 5)
+- [N/A] PHPStan — в проекте не установлен
+
+### Команды для проверки
+- `docker compose run --rm -T site-php-cli php bin/phpunit --testsuite integration --filter "AdRawDocumentDownloadControllerTest|AdScheduledBatchDownloadControllerTest|DownloadBronzeControllerTest"`
+- `grep -rn "getAbsolutePath" src/ | grep -v Shared/Service/Storage` → пусто
+
+### Риски / на что обратить внимание ревьюеру
+- **Content-Type** для `AdRawDocument`/`AdScheduledBatch` стал `application/octet-stream`
+  (раньше `BinaryFileResponse` угадывал text/csv). Для attachment-скачивания несущественно;
+  `DownloadBronze`/`DebugDownload` свой content-type сохранили.
+- **Байты стрима не проверяются** в integration-тестах: BrowserKit не буферизует
+  `StreamedResponse` (известное ограничение Symfony) — `getContent()`/`sendContent()`
+  дают пусто. Проверяем статус 200 + Content-Disposition + тип ответа + IDOR-404.
+- `DebugDownloadRawDocumentController` (MarketplaceAnalytics) отдельного теста не имеет
+  (debug-эндпоинт); покрыт `lint:container` + однотипностью паттерна с протестированными.
+
+### Открытые вопросы
+- нет

--- a/site/src/MarketplaceAds/Controller/AdRawDocumentDownloadController.php
+++ b/site/src/MarketplaceAds/Controller/AdRawDocumentDownloadController.php
@@ -6,16 +6,16 @@ namespace App\MarketplaceAds\Controller;
 
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
 use App\Shared\Service\ActiveCompanyService;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
 /**
- * Отдаёт raw-файл отчёта Ozon (csv/zip), сохранённый через StorageService.
+ * Отдаёт raw-файл отчёта Ozon (csv/zip) из объектного хранилища.
  *
  * Используется UI «История загрузок» — кнопкой «Открыть» на странице
  * «Реклама маркетплейсов» (task-8, 23.04.2026: парсинг временно отключён,
@@ -31,7 +31,7 @@ final class AdRawDocumentDownloadController extends AbstractController
     public function __construct(
         private readonly ActiveCompanyService $activeCompanyService,
         private readonly AdRawDocumentRepository $rawDocumentRepository,
-        private readonly StorageService $storageService,
+        private readonly ObjectStorageInterface $storage,
     ) {
     }
 
@@ -41,7 +41,7 @@ final class AdRawDocumentDownloadController extends AbstractController
         requirements: ['id' => '[0-9a-fA-F-]{36}'],
         methods: ['GET'],
     )]
-    public function __invoke(string $id): BinaryFileResponse
+    public function __invoke(string $id): StreamedResponse
     {
         $company = $this->activeCompanyService->getActiveCompany();
         $companyId = (string) $company->getId();
@@ -56,9 +56,8 @@ final class AdRawDocumentDownloadController extends AbstractController
             throw new NotFoundHttpException('Raw document has no stored file');
         }
 
-        $absolutePath = $this->storageService->getAbsolutePath($storagePath);
-        if (!is_file($absolutePath)) {
-            throw new NotFoundHttpException('File missing on disk');
+        if (!$this->storage->exists($storagePath)) {
+            throw new NotFoundHttpException('File missing in storage');
         }
 
         $extension = pathinfo($storagePath, \PATHINFO_EXTENSION) ?: 'bin';
@@ -68,10 +67,17 @@ final class AdRawDocumentDownloadController extends AbstractController
             $extension,
         );
 
-        $response = new BinaryFileResponse($absolutePath);
-        $response->setContentDisposition(
-            ResponseHeaderBag::DISPOSITION_ATTACHMENT,
-            $filename,
+        $stream = $this->storage->readStream($storagePath);
+        $response = new StreamedResponse(static function () use ($stream): void {
+            fpassthru($stream);
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        });
+        $response->headers->set('Content-Type', 'application/octet-stream');
+        $response->headers->set(
+            'Content-Disposition',
+            $response->headers->makeDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename),
         );
 
         return $response;

--- a/site/src/MarketplaceAds/Controller/AdRawDocumentDownloadController.php
+++ b/site/src/MarketplaceAds/Controller/AdRawDocumentDownloadController.php
@@ -80,6 +80,11 @@ final class AdRawDocumentDownloadController extends AbstractController
             $response->headers->makeDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename),
         );
 
+        $sizeBytes = $document->getFileSizeBytes();
+        if (null !== $sizeBytes) {
+            $response->headers->set('Content-Length', (string) $sizeBytes);
+        }
+
         return $response;
     }
 }

--- a/site/src/MarketplaceAds/Controller/AdScheduledBatchDownloadController.php
+++ b/site/src/MarketplaceAds/Controller/AdScheduledBatchDownloadController.php
@@ -6,10 +6,10 @@ namespace App\MarketplaceAds\Controller;
 
 use App\MarketplaceAds\Repository\AdScheduledBatchRepository;
 use App\Shared\Service\ActiveCompanyService;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
@@ -32,7 +32,7 @@ final class AdScheduledBatchDownloadController extends AbstractController
     public function __construct(
         private readonly ActiveCompanyService $activeCompanyService,
         private readonly AdScheduledBatchRepository $batchRepository,
-        private readonly StorageService $storageService,
+        private readonly ObjectStorageInterface $storage,
     ) {
     }
 
@@ -42,7 +42,7 @@ final class AdScheduledBatchDownloadController extends AbstractController
         requirements: ['id' => '[0-9a-fA-F-]{36}'],
         methods: ['GET'],
     )]
-    public function __invoke(string $id): BinaryFileResponse
+    public function __invoke(string $id): StreamedResponse
     {
         $company = $this->activeCompanyService->getActiveCompany();
         $companyId = (string) $company->getId();
@@ -59,9 +59,8 @@ final class AdScheduledBatchDownloadController extends AbstractController
             throw new NotFoundHttpException('Batch has no stored file');
         }
 
-        $absolutePath = $this->storageService->getAbsolutePath($storagePath);
-        if (!is_file($absolutePath)) {
-            throw new NotFoundHttpException('File missing on disk');
+        if (!$this->storage->exists($storagePath)) {
+            throw new NotFoundHttpException('File missing in storage');
         }
 
         $extension = pathinfo($storagePath, \PATHINFO_EXTENSION) ?: 'bin';
@@ -73,10 +72,17 @@ final class AdScheduledBatchDownloadController extends AbstractController
             $extension,
         );
 
-        $response = new BinaryFileResponse($absolutePath);
-        $response->setContentDisposition(
-            ResponseHeaderBag::DISPOSITION_ATTACHMENT,
-            $filename,
+        $stream = $this->storage->readStream($storagePath);
+        $response = new StreamedResponse(static function () use ($stream): void {
+            fpassthru($stream);
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        });
+        $response->headers->set('Content-Type', 'application/octet-stream');
+        $response->headers->set(
+            'Content-Disposition',
+            $response->headers->makeDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename),
         );
 
         return $response;

--- a/site/src/MarketplaceAds/Controller/AdScheduledBatchDownloadController.php
+++ b/site/src/MarketplaceAds/Controller/AdScheduledBatchDownloadController.php
@@ -85,6 +85,11 @@ final class AdScheduledBatchDownloadController extends AbstractController
             $response->headers->makeDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename),
         );
 
+        $sizeBytes = $batch->getFileSize();
+        if (null !== $sizeBytes) {
+            $response->headers->set('Content-Length', (string) $sizeBytes);
+        }
+
         return $response;
     }
 }

--- a/site/src/MarketplaceAds/Controller/Api/Admin/DownloadBronzeController.php
+++ b/site/src/MarketplaceAds/Controller/Api/Admin/DownloadBronzeController.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\MarketplaceAds\Controller\Api\Admin;
 
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
@@ -31,7 +31,7 @@ final class DownloadBronzeController extends AbstractController
 {
     public function __construct(
         private readonly AdRawDocumentRepository $adRawDocumentRepository,
-        private readonly StorageService $storageService,
+        private readonly ObjectStorageInterface $storage,
     ) {
     }
 
@@ -50,17 +50,20 @@ final class DownloadBronzeController extends AbstractController
             throw $this->createNotFoundException('Bronze file missing: document has no storage_path');
         }
 
-        $absolutePath = $this->storageService->getAbsolutePath($storagePath);
-        if (!is_file($absolutePath)) {
-            throw $this->createNotFoundException('Bronze file missing: file not found on disk');
+        if (!$this->storage->exists($storagePath)) {
+            throw $this->createNotFoundException('Bronze file missing: file not found in storage');
         }
 
         $extension = str_ends_with(strtolower($storagePath), '.zip') ? 'zip' : 'csv';
         $contentType = 'zip' === $extension ? 'application/zip' : 'text/csv';
         $filename = basename($storagePath);
 
-        $response = new StreamedResponse(static function () use ($absolutePath): void {
-            readfile($absolutePath);
+        $stream = $this->storage->readStream($storagePath);
+        $response = new StreamedResponse(static function () use ($stream): void {
+            fpassthru($stream);
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
         });
         $response->headers->set('Content-Type', $contentType);
         $response->headers->set(

--- a/site/src/MarketplaceAnalytics/Controller/Api/DebugDownloadRawDocumentController.php
+++ b/site/src/MarketplaceAnalytics/Controller/Api/DebugDownloadRawDocumentController.php
@@ -6,11 +6,11 @@ namespace App\MarketplaceAnalytics\Controller\Api;
 
 use App\Marketplace\Repository\MarketplaceRawDocumentRepository;
 use App\Shared\Service\ActiveCompanyService;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
-use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpFoundation\ResponseHeaderBag;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 use Symfony\Component\Routing\Attribute\Route;
 use Symfony\Component\Security\Http\Attribute\IsGranted;
 
@@ -44,7 +44,7 @@ final class DebugDownloadRawDocumentController extends AbstractController
     public function __construct(
         private readonly ActiveCompanyService $activeCompanyService,
         private readonly MarketplaceRawDocumentRepository $rawDocumentRepository,
-        private readonly StorageService $storageService,
+        private readonly ObjectStorageInterface $storage,
     ) {
     }
 
@@ -77,19 +77,28 @@ final class DebugDownloadRawDocumentController extends AbstractController
 
     private function serveFromDisk(array $rawData, string $periodFrom): Response
     {
-        $absolutePath = $this->storageService->getAbsolutePath($rawData['file_path']);
+        $storagePath = $rawData['file_path'];
 
-        if (!file_exists($absolutePath)) {
-            throw $this->createNotFoundException('Файл не найден на диске.');
+        if (!$this->storage->exists($storagePath)) {
+            throw $this->createNotFoundException('Файл не найден в хранилище.');
         }
 
         $contentType = $rawData['content_type'] ?? 'application/octet-stream';
-        $extension = self::EXTENSION_MAP[$contentType] ?? pathinfo($absolutePath, PATHINFO_EXTENSION) ?: 'bin';
+        $extension = self::EXTENSION_MAP[$contentType] ?? pathinfo($storagePath, \PATHINFO_EXTENSION) ?: 'bin';
         $filename = sprintf('mutual_settlement_%s.%s', $periodFrom, $extension);
 
-        $response = new BinaryFileResponse($absolutePath);
-        $response->setContentDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename);
+        $stream = $this->storage->readStream($storagePath);
+        $response = new StreamedResponse(static function () use ($stream): void {
+            fpassthru($stream);
+            if (is_resource($stream)) {
+                fclose($stream);
+            }
+        });
         $response->headers->set('Content-Type', $contentType);
+        $response->headers->set(
+            'Content-Disposition',
+            $response->headers->makeDisposition(ResponseHeaderBag::DISPOSITION_ATTACHMENT, $filename),
+        );
 
         return $response;
     }

--- a/site/tests/Integration/MarketplaceAds/Controller/AdRawDocumentDownloadControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/AdRawDocumentDownloadControllerTest.php
@@ -10,6 +10,7 @@ use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Builders\MarketplaceAds\AdRawDocumentBuilder;
 use App\Tests\Support\Kernel\WebTestCaseBase;
+use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
  * End-to-end тесты {@see \App\MarketplaceAds\Controller\AdRawDocumentDownloadController}.
@@ -82,6 +83,7 @@ final class AdRawDocumentDownloadControllerTest extends WebTestCaseBase
         self::assertResponseIsSuccessful();
 
         $response = $client->getResponse();
+        self::assertInstanceOf(StreamedResponse::class, $response);
         $disposition = (string) $response->headers->get('Content-Disposition');
         self::assertStringContainsString('attachment', $disposition);
         self::assertStringContainsString('ozon-ad-2026-04-01.csv', $disposition);


### PR DESCRIPTION
Шестой PR S3-миграции. **Последние `getAbsolutePath` закрыты.** От чистого master.

## Что тут
4 download-контроллера: `getAbsolutePath`+`BinaryFileResponse`/`readfile` → `readStream()`+`StreamedResponse` (`fpassthru`); наличие → `exists()`→404. Проксирование через приложение сохранено (без presigned URL, бакет приватный, IDOR/auth в контроллере). Драйвер `local`.

- `AdRawDocumentDownloadController`, `AdScheduledBatchDownloadController` — `application/octet-stream`
- `DownloadBronzeController` — сохранён zip/csv content-type + Content-Length
- `DebugDownloadRawDocumentController` — сохранён content_type; base64-ветка (legacy) не тронута

## 🎯 Веха: S3-гейт по коду закрыт
`grep getAbsolutePath src/` вне `Shared/Service/Storage/` — **пусто**. Все читатели на абстракции. Одно из предусловий флипа (PR 8) выполнено.

## Проверка
- download integration 14/14 (+ assert тип ответа `StreamedResponse`)
- `lint:container` OK; CS чисто (0 of 5)

## Заметки ревьюеру
- Content-Type для Ad*-контроллеров стал `application/octet-stream` (было — guess `BinaryFileResponse`); для attachment несущественно. Bronze/Debug сохранили свой content-type.
- **Байты стрима не проверяются**: BrowserKit не буферизует `StreamedResponse` (известное ограничение Symfony). Покрыто: 200 + Content-Disposition + тип ответа + IDOR-404.
- `DebugDownloadRawDocumentController` без отдельного теста (debug); покрыт lint + однотипностью.

Stage Report: `docs/tasks/s3-migration/stages/stage-6.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)