### PR TITLE
refactor(storage): PR 7 — спрятать StorageService (@internal)

### DIFF
--- a/docs/tasks/s3-migration/stages/stage-7.md
+++ b/docs/tasks/s3-migration/stages/stage-7.md
@@ -1,0 +1,54 @@
+## Stage 7 (PR 7): Спрятать StorageService (@internal) — DONE
+
+**Риск:** 🟢 LOW (документация + чистка тестов, рантайм не меняется)
+**Следующее действие:** continue autonomously → остаётся только PR 8 (инфра-флип, 🔴 STOP)
+**Ветка:** от чистого master
+
+### Что сделано
+- **`StorageService` помечен `@internal`** — низкоуровневый драйвер локального диска
+  для `LocalObjectStorage`. Прикладной код обязан работать через `ObjectStorageInterface`
+  (запись — `write()`, чтение для парсеров — `TemporaryLocalFile`). Прямое использование
+  вне пакета Storage запрещено.
+- **DI:** `StorageService` уже private (Symfony `_defaults`) — прод-код не может его
+  инжектить/`->get()`. Публичность не менялась.
+- **Причёсаны 3 прикладных integration-теста** (из ревью PR 5b, заметка A): setup файлов
+  переведён со `StorageService` на `ObjectStorageInterface`:
+  - `AdRawDocumentDownloadControllerTest`, `AdScheduledBatchDownloadControllerTest`,
+    `ExtractBatchesControllerTest`: `get(StorageService)` → `get(ObjectStorageInterface)`;
+    `storeBytes($body,$path)` → `write($path,$body)`; `$stored['storagePath']` → `$stored->path`,
+    `$stored['fileHash']` → `hash('sha256',$body)` (или фикстур-хеш, где не проверяется);
+    `@unlink(getAbsolutePath())` → `delete()`; `assertFileExists(getAbsolutePath())` →
+    `assertTrue(exists())`.
+
+### Осознанно НЕ трогали (легитимное driver-уровневое использование)
+- `StorageServiceTest`, `StorageServiceIntegrationTest` — тестируют сам `StorageService`.
+- `LocalObjectStorageTest` — мокает драйвер (тестирует делегацию local-обёртки).
+- `ObjectStorageIntegrationTest` — проверяет, что local-драйвер пишет по пути `StorageService`.
+- `ExtractBatchesToRawDocumentsActionTest` (unit) — конструирует `new StorageService($tmp)`
+  внутри `LocalObjectStorage`+`TemporaryLocalFile` (сборка local-драйвера для unit-теста).
+- `AdBatchPollerCommandTest` (integration) — мокает `StorageService` на уровне драйвера
+  (перехват через делегацию `LocalObjectStorage`).
+- `tests/bootstrap.php` — BypassFinals allowPaths для `StorageService` (нужен, т.к.
+  `LocalObjectStorageTest` и `AdBatchPoller` мокают финальный класс).
+
+### Затронутые файлы
+- `src/Shared/Service/Storage/StorageService.php` — modified (@internal docblock)
+- `tests/Integration/MarketplaceAds/Controller/AdRawDocumentDownloadControllerTest.php` — modified
+- `tests/Integration/MarketplaceAds/Controller/AdScheduledBatchDownloadControllerTest.php` — modified
+- `tests/Integration/MarketplaceAds/Controller/ExtractBatchesControllerTest.php` — modified
+
+### Self-review
+- [x] Scope compliance — @internal + чистка прикладных тестов; driver-уровневые не трогал
+- [x] Forbidden actions — none
+- [x] Tests green — converted 12/12; storage-layer + AdBatchPoller + ExtractBatches unit 52/52
+- [x] DI — `lint:container` OK (StorageService private, не менялся)
+- [~] CS-Fixer — 1 пред-существующее нарушение в `StorageService.php:94` (многострочный throw в `storeBytes`, не мой; докблок @internal чист)
+- [N/A] PHPStan — в проекте не установлен
+
+### Итог по коду
+Весь прикладной код — на `ObjectStorageInterface`; `StorageService` спрятан за `@internal`
+и private DI, остаётся только деталью local-драйвера. **Код-фаза миграции завершена.**
+Остался PR 8 — инфра-флип на S3 (🔴 STOP, за S3-гейтом).
+
+### Открытые вопросы
+- нет

--- a/site/src/Shared/Service/Storage/StorageService.php
+++ b/site/src/Shared/Service/Storage/StorageService.php
@@ -6,6 +6,14 @@ namespace App\Shared\Service\Storage;
 
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+/**
+ * Низкоуровневый драйвер локального диска для {@see LocalObjectStorage}.
+ *
+ * @internal Прикладной код обязан работать через {@see ObjectStorageInterface}
+ *           (запись — {@see ObjectStorageInterface::write()}, чтение файла для
+ *           парсеров — {@see TemporaryLocalFile}). Напрямую инжектить/использовать
+ *           этот класс вне пакета Storage запрещено.
+ */
 final class StorageService
 {
     public function __construct(private readonly string $storageRoot)

--- a/site/tests/Integration/MarketplaceAds/Controller/AdRawDocumentDownloadControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/AdRawDocumentDownloadControllerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Integration\MarketplaceAds\Controller;
 
 use App\Marketplace\Enum\MarketplaceType;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Builders\MarketplaceAds\AdRawDocumentBuilder;
@@ -47,8 +47,8 @@ final class AdRawDocumentDownloadControllerTest extends WebTestCaseBase
         $em->persist($company);
         $em->flush();
 
-        /** @var StorageService $storage */
-        $storage = static::getContainer()->get(StorageService::class);
+        /** @var ObjectStorageInterface $storage */
+        $storage = static::getContainer()->get(ObjectStorageInterface::class);
 
         $csvBody = "date;sku;spend\n2026-04-01;SKU-1;1.00";
         $relativePath = sprintf(
@@ -56,7 +56,7 @@ final class AdRawDocumentDownloadControllerTest extends WebTestCaseBase
             self::COMPANY_ID,
             'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
         );
-        $stored = $storage->storeBytes($csvBody, $relativePath);
+        $stored = $storage->write($relativePath, $csvBody);
 
         $doc = AdRawDocumentBuilder::aRawDocument()
             ->withCompanyId(self::COMPANY_ID)
@@ -65,9 +65,9 @@ final class AdRawDocumentDownloadControllerTest extends WebTestCaseBase
             ->withReportDate(new \DateTimeImmutable('2026-04-01'))
             ->build();
         $doc->setFileStorage(
-            $stored['storagePath'],
-            $stored['fileHash'],
-            (int) $stored['sizeBytes'],
+            $stored->path,
+            hash('sha256', $csvBody),
+            $stored->byteSize,
         );
 
         $em->persist($doc);
@@ -89,7 +89,7 @@ final class AdRawDocumentDownloadControllerTest extends WebTestCaseBase
         self::assertStringContainsString('ozon-ad-2026-04-01.csv', $disposition);
 
         // Cleanup — storage-файл на реальном диске, удаляем, чтобы не копить мусор между запусками.
-        @unlink($storage->getAbsolutePath($relativePath));
+        $storage->delete($relativePath);
     }
 
     public function testDownloadReturns404ForOtherCompanyDocument(): void
@@ -122,15 +122,15 @@ final class AdRawDocumentDownloadControllerTest extends WebTestCaseBase
         $em->persist($otherCompany);
         $em->flush();
 
-        /** @var StorageService $storage */
-        $storage = static::getContainer()->get(StorageService::class);
+        /** @var ObjectStorageInterface $storage */
+        $storage = static::getContainer()->get(ObjectStorageInterface::class);
 
         $relativePath = sprintf(
             'marketplace-ads/%s/%s.csv',
             self::OTHER_COMPANY_ID,
             'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb',
         );
-        $stored = $storage->storeBytes('foreign-body', $relativePath);
+        $stored = $storage->write($relativePath, 'foreign-body');
 
         $foreignDoc = AdRawDocumentBuilder::aRawDocument()
             ->withCompanyId(self::OTHER_COMPANY_ID)
@@ -139,9 +139,9 @@ final class AdRawDocumentDownloadControllerTest extends WebTestCaseBase
             ->withReportDate(new \DateTimeImmutable('2026-04-05'))
             ->build();
         $foreignDoc->setFileStorage(
-            $stored['storagePath'],
-            $stored['fileHash'],
-            (int) $stored['sizeBytes'],
+            $stored->path,
+            hash('sha256', 'foreign-body'),
+            $stored->byteSize,
         );
 
         $em->persist($foreignDoc);
@@ -156,7 +156,7 @@ final class AdRawDocumentDownloadControllerTest extends WebTestCaseBase
 
         self::assertResponseStatusCodeSame(404);
 
-        @unlink($storage->getAbsolutePath($relativePath));
+        $storage->delete($relativePath);
     }
 
     public function testDownloadReturns404WhenStoragePathIsNull(): void

--- a/site/tests/Integration/MarketplaceAds/Controller/AdScheduledBatchDownloadControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/AdScheduledBatchDownloadControllerTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace App\Tests\Integration\MarketplaceAds\Controller;
 
 use App\MarketplaceAds\Enum\AdScheduledBatchState;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
@@ -56,8 +56,8 @@ final class AdScheduledBatchDownloadControllerTest extends WebTestCaseBase
         $em->persist($job);
         $em->flush();
 
-        /** @var StorageService $storage */
-        $storage = static::getContainer()->get(StorageService::class);
+        /** @var ObjectStorageInterface $storage */
+        $storage = static::getContainer()->get(ObjectStorageInterface::class);
 
         $csvBody = "date,campaign_id,spend\n2026-04-01,camp-1,1.00";
         $relativePath = sprintf(
@@ -65,7 +65,7 @@ final class AdScheduledBatchDownloadControllerTest extends WebTestCaseBase
             self::COMPANY_ID,
             'cccccccc-cccc-cccc-cccc-cccccccccccc',
         );
-        $stored = $storage->storeBytes($csvBody, $relativePath);
+        $stored = $storage->write($relativePath, $csvBody);
 
         $batch = AdScheduledBatchBuilder::aBatch()
             ->withJobId($job->getId())
@@ -76,7 +76,7 @@ final class AdScheduledBatchDownloadControllerTest extends WebTestCaseBase
                 new \DateTimeImmutable('2026-04-15'),
             )
             ->withState(AdScheduledBatchState::OK)
-            ->withStorage($stored['storagePath'], $stored['fileHash'], (int) $stored['sizeBytes'])
+            ->withStorage($stored->path, hash('sha256', $csvBody), $stored->byteSize)
             ->build();
         $em->persist($batch);
         $em->flush();
@@ -94,7 +94,7 @@ final class AdScheduledBatchDownloadControllerTest extends WebTestCaseBase
         self::assertStringContainsString('attachment', $disposition);
         self::assertStringContainsString('ozon-ad-batch-3-2026-04-01_2026-04-15.csv', $disposition);
 
-        @unlink($storage->getAbsolutePath($relativePath));
+        $storage->delete($relativePath);
     }
 
     public function testDownloadReturns404ForOtherCompanyBatch(): void
@@ -132,22 +132,22 @@ final class AdScheduledBatchDownloadControllerTest extends WebTestCaseBase
         $em->persist($foreignJob);
         $em->flush();
 
-        /** @var StorageService $storage */
-        $storage = static::getContainer()->get(StorageService::class);
+        /** @var ObjectStorageInterface $storage */
+        $storage = static::getContainer()->get(ObjectStorageInterface::class);
 
         $relativePath = sprintf(
             'marketplace-ads/%s/%s.csv',
             self::OTHER_COMPANY_ID,
             'dddddddd-dddd-dddd-dddd-dddddddddddd',
         );
-        $stored = $storage->storeBytes('foreign-body', $relativePath);
+        $stored = $storage->write($relativePath, 'foreign-body');
 
         $foreignBatch = AdScheduledBatchBuilder::aBatch()
             ->withJobId($foreignJob->getId())
             ->withCompanyId(self::OTHER_COMPANY_ID)
             ->withIndex(0)
             ->withState(AdScheduledBatchState::OK)
-            ->withStorage($stored['storagePath'], $stored['fileHash'], (int) $stored['sizeBytes'])
+            ->withStorage($stored->path, hash('sha256', 'foreign-body'), $stored->byteSize)
             ->build();
         $em->persist($foreignBatch);
         $em->flush();
@@ -161,7 +161,7 @@ final class AdScheduledBatchDownloadControllerTest extends WebTestCaseBase
 
         self::assertResponseStatusCodeSame(404);
 
-        @unlink($storage->getAbsolutePath($relativePath));
+        $storage->delete($relativePath);
     }
 
     public function testDownloadReturns404WhenStoragePathIsNull(): void

--- a/site/tests/Integration/MarketplaceAds/Controller/ExtractBatchesControllerTest.php
+++ b/site/tests/Integration/MarketplaceAds/Controller/ExtractBatchesControllerTest.php
@@ -8,7 +8,7 @@ use App\MarketplaceAds\Enum\AdRawDocumentStatus;
 use App\MarketplaceAds\Enum\AdScheduledBatchState;
 use App\MarketplaceAds\Message\ProcessAdRawDocumentMessage;
 use App\MarketplaceAds\Repository\AdRawDocumentRepository;
-use App\Shared\Service\Storage\StorageService;
+use App\Shared\Service\Storage\ObjectStorageInterface;
 use App\Tests\Builders\Company\CompanyBuilder;
 use App\Tests\Builders\Company\UserBuilder;
 use App\Tests\Builders\MarketplaceAds\AdLoadJobBuilder;
@@ -61,8 +61,8 @@ final class ExtractBatchesControllerTest extends WebTestCaseBase
         $em->persist($job);
         $em->flush();
 
-        /** @var StorageService $storage */
-        $storage = static::getContainer()->get(StorageService::class);
+        /** @var ObjectStorageInterface $storage */
+        $storage = static::getContainer()->get(ObjectStorageInterface::class);
 
         $csvBody = "\xEF\xBB\xBF;Кампания по продвижению товаров № 22655731, период 23.04.2026-23.04.2026\n"
             ."sku;spend\n"
@@ -71,14 +71,14 @@ final class ExtractBatchesControllerTest extends WebTestCaseBase
             'marketplace-ads/%s/happy-path-batch.csv',
             self::COMPANY_ID,
         );
-        $stored = $storage->storeBytes($csvBody, $relativePath);
+        $stored = $storage->write($relativePath, $csvBody);
 
         $batch = AdScheduledBatchBuilder::aBatch()
             ->withJobId($job->getId())
             ->withCompanyId(self::COMPANY_ID)
             ->withIndex(0)
             ->withState(AdScheduledBatchState::OK)
-            ->withStorage($stored['storagePath'], $stored['fileHash'], (int) $stored['sizeBytes'])
+            ->withStorage($stored->path, 'fixture-hash', $stored->byteSize)
             ->build();
         $em->persist($batch);
         $em->flush();
@@ -113,9 +113,9 @@ final class ExtractBatchesControllerTest extends WebTestCaseBase
         self::assertSame(self::COMPANY_ID, $message->companyId);
         self::assertSame($docs[0]->getId(), $message->adRawDocumentId);
 
-        // Файл на диске остаётся — Task-13 удалит его, когда парсинг подтвердится.
-        self::assertFileExists($storage->getAbsolutePath($relativePath));
-        @unlink($storage->getAbsolutePath($relativePath));
+        // Файл в хранилище остаётся — Task-13 удалит его, когда парсинг подтвердится.
+        self::assertTrue($storage->exists($relativePath));
+        $storage->delete($relativePath);
     }
 
     public function testSecondInvocationSkipsExistingDocumentAndDispatchesNothing(): void
@@ -144,20 +144,20 @@ final class ExtractBatchesControllerTest extends WebTestCaseBase
         $em->persist($job);
         $em->flush();
 
-        /** @var StorageService $storage */
-        $storage = static::getContainer()->get(StorageService::class);
+        /** @var ObjectStorageInterface $storage */
+        $storage = static::getContainer()->get(ObjectStorageInterface::class);
         $relativePath = sprintf(
             'marketplace-ads/%s/idempotent-batch.csv',
             self::COMPANY_ID,
         );
-        $stored = $storage->storeBytes('sku;spend\nsku-1;1.00', $relativePath);
+        $stored = $storage->write($relativePath, 'sku;spend\nsku-1;1.00');
 
         $batch = AdScheduledBatchBuilder::aBatch()
             ->withJobId($job->getId())
             ->withCompanyId(self::COMPANY_ID)
             ->withIndex(0)
             ->withState(AdScheduledBatchState::OK)
-            ->withStorage($stored['storagePath'], $stored['fileHash'], (int) $stored['sizeBytes'])
+            ->withStorage($stored->path, 'fixture-hash', $stored->byteSize)
             ->build();
         $em->persist($batch);
         $em->flush();
@@ -196,7 +196,7 @@ final class ExtractBatchesControllerTest extends WebTestCaseBase
         $transportAfterSecondPost = static::getContainer()->get('messenger.transport.async_pipeline');
         self::assertCount(0, $transportAfterSecondPost->getSent());
 
-        @unlink($storage->getAbsolutePath($relativePath));
+        $storage->delete($relativePath);
     }
 
     public function testForeignJobIdReturns0ProcessedWithoutException(): void
@@ -235,20 +235,20 @@ final class ExtractBatchesControllerTest extends WebTestCaseBase
         $em->persist($foreignJob);
         $em->flush();
 
-        /** @var StorageService $storage */
-        $storage = static::getContainer()->get(StorageService::class);
+        /** @var ObjectStorageInterface $storage */
+        $storage = static::getContainer()->get(ObjectStorageInterface::class);
         $relativePath = sprintf(
             'marketplace-ads/%s/foreign-batch.csv',
             self::OTHER_COMPANY_ID,
         );
-        $stored = $storage->storeBytes('foreign-csv', $relativePath);
+        $stored = $storage->write($relativePath, 'foreign-csv');
 
         $foreignBatch = AdScheduledBatchBuilder::aBatch()
             ->withJobId($foreignJob->getId())
             ->withCompanyId(self::OTHER_COMPANY_ID)
             ->withIndex(0)
             ->withState(AdScheduledBatchState::OK)
-            ->withStorage($stored['storagePath'], $stored['fileHash'], (int) $stored['sizeBytes'])
+            ->withStorage($stored->path, 'fixture-hash', $stored->byteSize)
             ->build();
         $em->persist($foreignBatch);
         $em->flush();
@@ -274,7 +274,7 @@ final class ExtractBatchesControllerTest extends WebTestCaseBase
         $transport = static::getContainer()->get('messenger.transport.async_pipeline');
         self::assertCount(0, $transport->getSent());
 
-        @unlink($storage->getAbsolutePath($relativePath));
+        $storage->delete($relativePath);
     }
 
     public function testInvalidCsrfTokenReturns400(): void


### PR DESCRIPTION
Седьмой PR S3-миграции. **Завершает код-фазу.** От чистого master.

## Что тут
- `StorageService` помечен **`@internal`** — низкоуровневый драйвер local-диска для `LocalObjectStorage`. Прикладной код обязан работать через `ObjectStorageInterface` (`write()` / `TemporaryLocalFile`). В DI уже private (Symfony default).
- **3 прикладных integration-теста** переведены со `StorageService` на `ObjectStorageInterface` (`write`/`delete`/`exists`): `AdRawDocumentDownload`, `AdScheduledBatchDownload`, `ExtractBatchesController`. Закрыта заметка A из ревью PR 5b.

## Осознанно не трогали (driver-уровень)
`StorageServiceTest`, `LocalObjectStorageTest`, `StorageServiceIntegrationTest`, `ObjectStorageIntegrationTest`, `ExtractBatches` unit, `AdBatchPoller` integration (мокает драйвер), `bootstrap.php` BypassFinals.

## Проверка
- converted 12/12; storage-layer + AdBatchPoller + ExtractBatches unit 52/52
- `lint:container` OK; CS: 1 пред-существующее (`StorageService:94`, не моё)

## 🏁 Код-фаза завершена
Весь код — на `ObjectStorageInterface`; `StorageService` спрятан. Остаётся PR 8 (инфра-флип на S3, за STOP).

Stage Report: `docs/tasks/s3-migration/stages/stage-7.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)