### PR TITLE
chore(storage): PR 8 (wiring) — S3 env для прода, driver=local

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -135,6 +135,8 @@ jobs:
                     export SENTRY_DSN="${{ secrets.SENTRY_DSN }}"
                     export SENTRY_RELEASE="${{ github.sha }}"
                     export HEALTH_CHECK_TOKEN="${{ secrets.HEALTH_CHECK_TOKEN }}"
+                    export APP_OBJECT_STORAGE_S3_ACCESS_KEY="${{ secrets.APP_OBJECT_STORAGE_S3_ACCESS_KEY }}"
+                    export APP_OBJECT_STORAGE_S3_SECRET_KEY="${{ secrets.APP_OBJECT_STORAGE_S3_SECRET_KEY }}"
 
                     echo "🚚 Скачивание свежих образов из GHCR"
                     docker compose -f docker-compose.prod.yml pull land site site-php-fpm site-php-cli
@@ -208,6 +210,8 @@ jobs:
                     export SENTRY_DSN="${{ secrets.SENTRY_DSN }}"
                     export SENTRY_RELEASE="${{ github.sha }}"
                     export HEALTH_CHECK_TOKEN="${{ secrets.HEALTH_CHECK_TOKEN }}"
+                    export APP_OBJECT_STORAGE_S3_ACCESS_KEY="${{ secrets.APP_OBJECT_STORAGE_S3_ACCESS_KEY }}"
+                    export APP_OBJECT_STORAGE_S3_SECRET_KEY="${{ secrets.APP_OBJECT_STORAGE_S3_SECRET_KEY }}"
 
                     docker compose -f docker-compose.prod.yml run --rm site-php-cli bin/console doctrine:migrations:migrate --no-interaction
                     echo "✅ Миграции применены"

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -36,6 +36,18 @@ x-php-env: &php-env
     TELEGRAM_WEBHOOK_SECRET: ${TELEGRAM_WEBHOOK_SECRET:-}
     # Базовый URL Telegram Bot API через шлюз tg-gateway (app-сервер не имеет прямого доступа к api.telegram.org)
     TELEGRAM_API_BASE_URL: ${TELEGRAM_API_BASE_URL:-https://tg.vashfindir.ru/bot-api}
+    # ─── Объектное хранилище файлов (timeweb S3) ───────────────────────────
+    # DRIVER=local до завершения `aws s3 sync`. Флип на s3 — отдельным однострочным
+    # коммитом (S3-гейт: сначала данные в бакете, потом переключение). Откат — обратно на local.
+    APP_OBJECT_STORAGE_DRIVER: local
+    APP_OBJECT_STORAGE_S3_ENDPOINT: "https://s3.twcstorage.ru"
+    APP_OBJECT_STORAGE_S3_BUCKET: "ccd24eb8-1c82-4de4-bd69-9706a7b5443b"
+    APP_OBJECT_STORAGE_S3_REGION: "ru-1"
+    # Если бакет не резолвится virtual-hosted стилем — переключить на "1" (path-style)
+    APP_OBJECT_STORAGE_S3_PATH_STYLE_ENDPOINT: "0"
+    # Ключи — только через GitHub Secrets (deploy.yml экспортирует их в host-env)
+    APP_OBJECT_STORAGE_S3_ACCESS_KEY: ${APP_OBJECT_STORAGE_S3_ACCESS_KEY:-}
+    APP_OBJECT_STORAGE_S3_SECRET_KEY: ${APP_OBJECT_STORAGE_S3_SECRET_KEY:-}
 
 services:
 
@@ -411,6 +423,14 @@ services:
             WB_LEGACY_RECONCILE_ENABLED: ${WB_LEGACY_RECONCILE_ENABLED:-0}
             # Нужно для app:telegram:send-reports (исходящие в Telegram через шлюз)
             TELEGRAM_API_BASE_URL: ${TELEGRAM_API_BASE_URL:-https://tg.vashfindir.ru/bot-api}
+            # ─── Объектное хранилище (timeweb S3) — cron-команды тоже читают/пишут файлы ───
+            APP_OBJECT_STORAGE_DRIVER: local
+            APP_OBJECT_STORAGE_S3_ENDPOINT: "https://s3.twcstorage.ru"
+            APP_OBJECT_STORAGE_S3_BUCKET: "ccd24eb8-1c82-4de4-bd69-9706a7b5443b"
+            APP_OBJECT_STORAGE_S3_REGION: "ru-1"
+            APP_OBJECT_STORAGE_S3_PATH_STYLE_ENDPOINT: "0"
+            APP_OBJECT_STORAGE_S3_ACCESS_KEY: ${APP_OBJECT_STORAGE_S3_ACCESS_KEY:-}
+            APP_OBJECT_STORAGE_S3_SECRET_KEY: ${APP_OBJECT_STORAGE_S3_SECRET_KEY:-}
         volumes:
             - ./docker/cron/app.cron:/etc/crontabs/app.cron:ro
             - site_storage:/app/var/storage

--- a/docs/tasks/s3-migration/runbook-cutover.md
+++ b/docs/tasks/s3-migration/runbook-cutover.md
@@ -1,0 +1,99 @@
+# S3 Cutover — Runbook (PR 8)
+
+Инфра-этап миграции. Код полностью на `ObjectStorageInterface` (PR 1–7). Здесь —
+проброс env и операционный переезд на timeweb S3.
+
+## Что сделано в этом PR (wiring, безопасно)
+
+- `docker-compose.prod.yml` — в `x-php-env` (php-fpm + все воркеры) и в блок env
+  `scheduler` добавлены 7 переменных `APP_OBJECT_STORAGE_*`.
+- **`APP_OBJECT_STORAGE_DRIVER: local`** — жёстко, поэтому деплой **ничего не меняет**
+  в поведении (файлы по-прежнему на локальном диске).
+- Конфиг захардкожен: endpoint `https://s3.twcstorage.ru`, bucket
+  `ccd24eb8-1c82-4de4-bd69-9706a7b5443b`, region `ru-1`, path-style `0`.
+- Ключи — из GitHub Secrets: `APP_OBJECT_STORAGE_S3_ACCESS_KEY`,
+  `APP_OBJECT_STORAGE_S3_SECRET_KEY` (экспортируются в `deploy.yml`, jobs deploy+migrations).
+
+Мержим и деплоим этот PR **до** переезда — он лишь готовит окружение.
+
+## Предусловия перед флипом
+
+- [ ] Бакет timeweb создан: приватный, versioning ON, lifecycle (удалять неактуальные
+      версии через 30 дней). SSE-S3 — подготовлено, но не включаем (по решению Владельца).
+- [ ] Секреты `APP_OBJECT_STORAGE_S3_ACCESS_KEY/SECRET_KEY` в GitHub — добавлены ✅.
+- [ ] Этот wiring-PR задеплоен (DRIVER всё ещё `local`).
+- [ ] PR 3/4/5 в проде (cash/telegram/parsers) ✅ — S3-гейт по коду закрыт.
+
+## Шаг 1 — Smoke-тест доступа к S3 (до флипа, без риска)
+
+С прод-сервера, реальными ключами, проверить, что бакет доступен и стиль URL верный:
+
+```bash
+docker run --rm \
+  -e AWS_ACCESS_KEY_ID="<ACCESS_KEY>" \
+  -e AWS_SECRET_ACCESS_KEY="<SECRET_KEY>" \
+  amazon/aws-cli \
+  --endpoint-url https://s3.twcstorage.ru --region ru-1 \
+  s3 ls s3://ccd24eb8-1c82-4de4-bd69-9706a7b5443b
+```
+
+Если ошибка резолва/доступа к бакету — переключить `APP_OBJECT_STORAGE_S3_PATH_STYLE_ENDPOINT`
+на `"1"` (path-style) в compose и повторить.
+
+## Шаг 2 — Sync данных в бакет (копия, приложение живёт)
+
+Объём мал (~72 МБ / 14 файлов), но storage-корень `var/storage` собран из двух томов:
+`current_site_storage` (→ var/storage) и `current_site_company_storage` (→ var/storage/companies).
+Монтируем оба и синкаем **с сохранением относительных путей = ключей**:
+
+```bash
+docker run --rm \
+  -v current_site_storage:/data/storage \
+  -v current_site_company_storage:/data/storage/companies \
+  -e AWS_ACCESS_KEY_ID="<ACCESS_KEY>" \
+  -e AWS_SECRET_ACCESS_KEY="<SECRET_KEY>" \
+  amazon/aws-cli \
+  --endpoint-url https://s3.twcstorage.ru --region ru-1 \
+  s3 sync /data/storage s3://ccd24eb8-1c82-4de4-bd69-9706a7b5443b
+```
+
+`sync` = копирование (не move), локальный том остаётся. Идемпотентен — можно гонять повторно.
+
+## Шаг 3 — Короткая пауза + догоняющий sync
+
+1. Остановить приём загрузок / воркеры (короткое окно — секунды, данных мало):
+   ```bash
+   docker compose -f docker-compose.prod.yml stop \
+     site-messenger-worker-sync site-messenger-worker-pipeline \
+     site-messenger-worker-ads site-messenger-worker-wb-finance scheduler
+   ```
+2. Повторить `s3 sync` (шаг 2) — догоняет всё, что налилось за время первого синка.
+
+## Шаг 4 — Флип на S3
+
+Изменить `APP_OBJECT_STORAGE_DRIVER: local` → `s3` в **ДВУХ местах**
+`docker-compose.prod.yml` (блок `x-php-env` и блок `scheduler`), закоммитить, задеплоить.
+Одна строка × 2 — легко ревьюить и откатывать.
+
+После деплоя воркеры/scheduler поднимутся автоматически (rolling update в `deploy.yml`).
+
+## Шаг 5 — Сверка паритета
+
+Пройти по путям файлов из БД и проверить существование в S3 (count + пара пробных read).
+Разово, не глазами. (Скрипт-команду добавить при флипе или прогнать `aws s3 ls`-сверку
+против списка `storage_path` из соответствующих таблиц.)
+
+## Шаг 6 — Грейс + удаление local
+
+- Локальные тома **не трогать** 2 недели (холодный бэкап).
+- Мониторить GlitchTip на ошибки «файл не найден» / `ObjectStorageException`.
+- Через 2 недели без инцидентов + зелёная сверка → удалить локальные тома (решение Владельца).
+
+## Откат (в любой момент до удаления local)
+
+Вернуть `APP_OBJECT_STORAGE_DRIVER` → `local` (2 строки) + деплой. Данные на локальном
+томе на месте (sync был копией). Файлы, загруженные ПОСЛЕ флипа, останутся только в S3 —
+их домигрировать обратно `aws s3 sync s3://... /data/storage` перед откатом, если критично.
+
+## Открытые вопросы
+- path-style `0` vs `1` для timeweb — подтвердить smoke-тестом (шаг 1) до флипа.


### PR DESCRIPTION
Инфра-этап S3-миграции. **Проброс env без смены поведения** (`DRIVER=local`).

## Что тут
- **`docker-compose.prod.yml`**: 7 `APP_OBJECT_STORAGE_*` в `x-php-env` (php-fpm + воркеры) и в блок env `scheduler`. `DRIVER: local` жёстко → деплой поведенчески **no-op** (файлы на локальном диске). endpoint/bucket/region/path-style захардкожены; ключи — из `${...}`.
- **`deploy.yml`**: `export APP_OBJECT_STORAGE_S3_ACCESS_KEY/SECRET_KEY` из GitHub Secrets в jobs `deploy` и `migrations`.
- **`runbook-cutover.md`**: smoke-тест → `s3 sync` → флип (`local`→`s3`, 2 строки) → сверка → грейс 2 недели → удалить local. Откат = driver назад на local.

## Значения (timeweb)
- endpoint `https://s3.twcstorage.ru`, bucket `ccd24eb8-...`, region `ru-1`, path-style `0`.
- Секреты в GitHub добавлены Владельцем: `..._S3_ACCESS_KEY`, `..._S3_SECRET_KEY`.

## Безопасность
- `docker compose config` валиден; S3-env отрендерился во все php-сервисы + scheduler.
- **Флип на `s3` — отдельный однострочный коммит после `s3 sync`** (S3-гейт: сначала данные в бакете). Этот PR ничего не переключает.

🔴 Инфра-PR (compose + CI). Деплой безопасен (DRIVER=local), но требует ревью Владельца.

Runbook: `docs/tasks/s3-migration/runbook-cutover.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)