### PR TITLE
docs(env): задокументировать object storage переменные в site/.env

### DIFF
--- a/site/.env
+++ b/site/.env
@@ -92,3 +92,18 @@ APP_ENCRYPTION_KEY_FILE=%kernel.project_dir%/var/secrets/encryption_keys.json
 APP_ENCRYPTION_CURRENT_KEY_VERSION=v1
 APP_ENCRYPTION_FALLBACK_KEY=
 ###< app encryption ###
+
+###> object storage ###
+# Хранилище файлов (загрузки импортов, raw-выгрузки маркетплейсов).
+# local — локальный диск var/storage (dev/test по умолчанию); s3 — объектное хранилище.
+# Прикладной код всегда работает через ObjectStorageInterface, драйвер прозрачен.
+APP_OBJECT_STORAGE_DRIVER=local
+# S3 задаётся только при DRIVER=s3 (прод — через docker-compose.prod.yml + GitHub Secrets).
+# Для локальной проверки S3-пути раскомментируй и подставь свои значения (напр. MinIO) в .env.local:
+# APP_OBJECT_STORAGE_S3_ENDPOINT=https://s3.twcstorage.ru
+# APP_OBJECT_STORAGE_S3_BUCKET=
+# APP_OBJECT_STORAGE_S3_REGION=ru-1
+# APP_OBJECT_STORAGE_S3_PATH_STYLE_ENDPOINT=0
+# APP_OBJECT_STORAGE_S3_ACCESS_KEY=
+# APP_OBJECT_STORAGE_S3_SECRET_KEY=
+###< object storage ###


### PR DESCRIPTION
Discoverability-правка для DEV. `site/.env` (Symfony-шаблон env) не упоминал `APP_OBJECT_STORAGE_*` — добавил секцию.

## Что тут
- `APP_OBJECT_STORAGE_DRIVER=local` — совпадает с существующим дефолтом service-параметра, поведение DEV **не меняется**.
- S3-переменные закомментированы — для опциональной локальной проверки S3-пути (MinIO / реальный бакет) через `.env.local`.

DEV и раньше работал корректно (дефолт `local` через `%env(default:...)%`) — это чисто документация/discoverability.

`lint:container` — OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)