### PR TITLE
feat(storage): мониторинг живости S3 — healthcheck-команда + logging-декоратор

### DIFF
--- a/docker/cron/app.cron
+++ b/docker/cron/app.cron
@@ -115,3 +115,7 @@
 
 # Ежедневно в 03:00: чистка логов/временных таблиц
 #0 3 * * * php /app/bin/console app:maintenance:cleanup --env=prod
+
+# Каждые 5 минут: синтетическая проверка живости объектного хранилища (write→read→delete).
+# Сбой → logger->error → GlitchTip. Успех печатает "OK (N ms)" в docker logs (heartbeat).
+*/5 * * * * cd /app && php bin/console app:storage:healthcheck --no-interaction >> /proc/1/fd/1 2>> /proc/1/fd/2

--- a/docs/tasks/s3-migration/monitoring.md
+++ b/docs/tasks/s3-migration/monitoring.md
@@ -1,0 +1,47 @@
+# S3 — мониторинг живости хранилища
+
+Наблюдаемость объектного хранилища (`ObjectStorageInterface`). Принцип: **liveness ≠
+readiness** — сбой S3 НЕ должен валить container-healthcheck php-fpm (`/health`), иначе
+traefik выкинет ноду из ротации (amplification). Поэтому мониторинг — отдельно.
+
+## #1 — Синтетический health-check (проактивно)
+
+Команда `app:storage:healthcheck` (`src/Shared/Command/StorageHealthCheckCommand.php`):
+`write` → `read` → verify → `delete` крошечного probe-объекта (`_healthcheck/probe-*.txt`)
+с замером латентности.
+
+- Крон (supercronic, `docker/cron/app.cron`): `*/5 * * * *`.
+- Сбой (недоступность S3 / протухшие ключи / read-back mismatch) → `logger->error` →
+  **GlitchTip алерт** + exit 1. Успех печатает `OK (N ms)` в docker logs (heartbeat).
+- Ловит проблему до того, как её увидит пользователь.
+
+## #2 — Инструментирующий декоратор
+
+`LoggingObjectStorage` (`src/Shared/Service/Storage/LoggingObjectStorage.php`) декорирует
+`ObjectStorageInterface` через DI (`decorates:` в `services.yaml`). Прозрачен для всего
+прикладного кода:
+
+- Таймит каждую операцию (write/read/readStream/exists/delete).
+- `warning` на медленных (`> app.object_storage_slow_ms`, дефолт 1000 мс) — только лог.
+- `error` на сбоях со структурным контекстом (operation, path, duration_ms, exception) →
+  GlitchTip. Реросит исходное исключение.
+- Даёт латентность и error-rate на **реальных** боевых путях (не только синтетика).
+
+## Уровни (по правилам логирования проекта)
+
+- `error` — сбой операции хранилища = инцидент (будим человека) → GlitchTip.
+  AWS SDK уже ретраит внутри, так что исключение = неустранимый сбой, не transient.
+- `warning` — медленная операция: ожидаемо, обрабатывается само, в GlitchTip не идёт.
+
+## Что НЕ делали (осознанно)
+
+- S3 в container `/health` — amplification.
+- Circuit breaker / retry-слой — timeweb managed, SDK ретраит; добавлять только при
+  реальных transient-сбоях.
+- INFO на каждую операцию — шум.
+
+## Возможные follow-ups
+
+- Readiness-эндпоинт `/health/storage` (под `HEALTH_CHECK_TOKEN`) для внешнего аптайм-монитора.
+- Lifecycle-правило на префикс `_healthcheck/` в бакете (на случай, если delete probe не
+  прошёл при частичном сбое — чтобы не копились).

--- a/site/config/services.yaml
+++ b/site/config/services.yaml
@@ -15,6 +15,8 @@ parameters:
     app.object_storage_s3_access_key_default: ''
     app.object_storage_s3_secret_key_default: ''
     app.object_storage_s3_path_style_endpoint_default: '0'
+    # Порог «медленной» операции хранилища (мс) для LoggingObjectStorage → warning
+    app.object_storage_slow_ms: 1000
     wb_finance.rate_limit_interval_seconds: 70
     wb_finance.retry_delay_ms: 70000
     ozon_performance.api_base_url_default: 'https://api-performance.ozon.ru'
@@ -112,6 +114,13 @@ services:
     App\Ingestion\Command\OzonAccrualCategoryMetadataBulkRunnerInterface: '@App\Ingestion\Command\OzonAccrualCategoryMetadataBulkRunner'
     App\Shared\Service\Storage\ObjectStorageInterface:
         factory: ['@App\Shared\Service\Storage\ObjectStorageFactory', 'create']
+
+    # Инструментация: таймит операции, warning на медленных, error на сбоях → GlitchTip.
+    App\Shared\Service\Storage\LoggingObjectStorage:
+        decorates: App\Shared\Service\Storage\ObjectStorageInterface
+        arguments:
+            $inner: '@.inner'
+            $slowMs: '%app.object_storage_slow_ms%'
 
     App\Shared\Service\Storage\ObjectStorageFactory:
         arguments:

--- a/site/src/Shared/Command/StorageHealthCheckCommand.php
+++ b/site/src/Shared/Command/StorageHealthCheckCommand.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Command;
+
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+/**
+ * Синтетическая проверка живости объектного хранилища: write → read → verify → delete
+ * крошечного probe-объекта, с замером латентности.
+ *
+ * Запускается кроном (supercronic). При сбое — logger->error → GlitchTip алерт, exit 1.
+ * Проактивно ловит недоступность S3 / протухшие ключи / деградацию латентности до того,
+ * как это увидит пользователь.
+ */
+#[AsCommand(
+    name: 'app:storage:healthcheck',
+    description: 'Синтетическая проверка живости объектного хранилища (write→read→delete).',
+)]
+final class StorageHealthCheckCommand extends Command
+{
+    public function __construct(
+        private readonly ObjectStorageInterface $storage,
+        private readonly LoggerInterface $logger,
+    ) {
+        parent::__construct();
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $key = sprintf('_healthcheck/probe-%s.txt', bin2hex(random_bytes(8)));
+        $payload = 'probe-'.bin2hex(random_bytes(8));
+        $startedAt = microtime(true);
+
+        try {
+            $this->storage->write($key, $payload);
+            $readBack = $this->storage->read($key);
+            $this->storage->delete($key);
+
+            if ($readBack !== $payload) {
+                throw new \RuntimeException('Read-back payload mismatch — повреждение данных или чужой объект.');
+            }
+        } catch (\Throwable $exception) {
+            $durationMs = $this->elapsedMs($startedAt);
+            $this->logger->error('Object storage healthcheck FAILED', [
+                'key' => $key,
+                'duration_ms' => $durationMs,
+                'exception' => $exception,
+            ]);
+            $output->writeln(sprintf('<error>storage healthcheck FAILED (%d ms): %s</error>', $durationMs, $exception->getMessage()));
+
+            // Best-effort уборка probe-объекта, если write прошёл, а read — нет. Не маскируем исходную ошибку.
+            try {
+                $this->storage->delete($key);
+            } catch (\Throwable) {
+            }
+
+            return Command::FAILURE;
+        }
+
+        $output->writeln(sprintf('storage healthcheck OK (%d ms)', $this->elapsedMs($startedAt)));
+
+        return Command::SUCCESS;
+    }
+
+    private function elapsedMs(float $startedAt): int
+    {
+        return (int) round((microtime(true) - $startedAt) * 1000);
+    }
+}

--- a/site/src/Shared/Service/Storage/LoggingObjectStorage.php
+++ b/site/src/Shared/Service/Storage/LoggingObjectStorage.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Shared\Service\Storage;
+
+use Psr\Log\LoggerInterface;
+
+/**
+ * Декоратор {@see ObjectStorageInterface}: инструментирует все операции хранилища —
+ * таймит, логирует `warning` на медленных (> slowMs) и `error` на сбоях со структурным
+ * контекстом. Реросит исходное исключение. Прозрачен для вызывающего кода.
+ *
+ * error → GlitchTip (сбой хранилища = инцидент). warning (медленно) — только в лог.
+ */
+final readonly class LoggingObjectStorage implements ObjectStorageInterface
+{
+    public function __construct(
+        private ObjectStorageInterface $inner,
+        private LoggerInterface $logger,
+        private int $slowMs = 1000,
+    ) {
+    }
+
+    public function write(string $path, string $contents): StoredObject
+    {
+        return $this->measured('write', $path, fn (): StoredObject => $this->inner->write($path, $contents));
+    }
+
+    public function read(string $path): string
+    {
+        return $this->measured('read', $path, fn (): string => $this->inner->read($path));
+    }
+
+    public function readStream(string $path)
+    {
+        return $this->measured('readStream', $path, fn () => $this->inner->readStream($path));
+    }
+
+    public function exists(string $path): bool
+    {
+        return $this->measured('exists', $path, fn (): bool => $this->inner->exists($path));
+    }
+
+    public function delete(string $path): void
+    {
+        $this->measured('delete', $path, fn () => $this->inner->delete($path));
+    }
+
+    /**
+     * @template T
+     *
+     * @param callable(): T $callback
+     *
+     * @return T
+     */
+    private function measured(string $operation, string $path, callable $callback): mixed
+    {
+        $startedAt = microtime(true);
+
+        try {
+            $result = $callback();
+        } catch (\Throwable $exception) {
+            $this->logger->error('Object storage operation failed', [
+                'operation' => $operation,
+                'path' => $path,
+                'duration_ms' => $this->elapsedMs($startedAt),
+                'exception' => $exception,
+            ]);
+
+            throw $exception;
+        }
+
+        $durationMs = $this->elapsedMs($startedAt);
+        if ($durationMs >= $this->slowMs) {
+            $this->logger->warning('Object storage operation slow', [
+                'operation' => $operation,
+                'path' => $path,
+                'duration_ms' => $durationMs,
+                'threshold_ms' => $this->slowMs,
+            ]);
+        }
+
+        return $result;
+    }
+
+    private function elapsedMs(float $startedAt): int
+    {
+        return (int) round((microtime(true) - $startedAt) * 1000);
+    }
+}

--- a/site/tests/Unit/Shared/Command/StorageHealthCheckCommandTest.php
+++ b/site/tests/Unit/Shared/Command/StorageHealthCheckCommandTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Command;
+
+use App\Shared\Command\StorageHealthCheckCommand;
+use App\Shared\Service\Storage\ObjectStorageException;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Shared\Service\Storage\StoredObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Tester\CommandTester;
+
+final class StorageHealthCheckCommandTest extends TestCase
+{
+    public function testHealthyRoundTripReturnsSuccess(): void
+    {
+        $written = null;
+
+        $storage = $this->createMock(ObjectStorageInterface::class);
+        $storage->method('write')->willReturnCallback(
+            function (string $key, string $contents) use (&$written): StoredObject {
+                $written = $contents;
+
+                return new StoredObject($key, \strlen($contents));
+            },
+        );
+        // read возвращает ровно то, что записали → payload совпадает → healthcheck OK.
+        // Захват $written ПО ССЫЛКЕ — иначе увидим null (значение на момент определения).
+        $storage->method('read')->willReturnCallback(function () use (&$written): string {
+            return (string) $written;
+        });
+        $storage->expects(self::atLeastOnce())->method('delete');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('error');
+
+        $tester = new CommandTester(new StorageHealthCheckCommand($storage, $logger));
+
+        self::assertSame(Command::SUCCESS, $tester->execute([]));
+        self::assertStringContainsString('OK', $tester->getDisplay());
+    }
+
+    public function testStorageFailureLogsErrorAndReturnsFailure(): void
+    {
+        $storage = $this->createMock(ObjectStorageInterface::class);
+        $storage->method('write')->willThrowException(new ObjectStorageException('S3 unreachable'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with('Object storage healthcheck FAILED', self::callback(
+                static fn (array $context): bool => array_key_exists('key', $context)
+                    && array_key_exists('duration_ms', $context)
+                    && $context['exception'] instanceof ObjectStorageException,
+            ));
+
+        $tester = new CommandTester(new StorageHealthCheckCommand($storage, $logger));
+
+        self::assertSame(Command::FAILURE, $tester->execute([]));
+    }
+
+    public function testReadBackMismatchIsTreatedAsFailure(): void
+    {
+        $storage = $this->createMock(ObjectStorageInterface::class);
+        $storage->method('write')->willReturnCallback(
+            static fn (string $key, string $contents): StoredObject => new StoredObject($key, \strlen($contents)),
+        );
+        // read возвращает НЕ то, что записали → повреждение → FAILURE.
+        $storage->method('read')->willReturn('corrupted-payload');
+        $storage->method('delete');
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())->method('error')->with('Object storage healthcheck FAILED', self::anything());
+
+        $tester = new CommandTester(new StorageHealthCheckCommand($storage, $logger));
+
+        self::assertSame(Command::FAILURE, $tester->execute([]));
+    }
+}

--- a/site/tests/Unit/Shared/Service/Storage/LoggingObjectStorageTest.php
+++ b/site/tests/Unit/Shared/Service/Storage/LoggingObjectStorageTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Tests\Unit\Shared\Service\Storage;
+
+use App\Shared\Service\Storage\LoggingObjectStorage;
+use App\Shared\Service\Storage\ObjectStorageException;
+use App\Shared\Service\Storage\ObjectStorageInterface;
+use App\Shared\Service\Storage\StoredObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\LoggerInterface;
+
+final class LoggingObjectStorageTest extends TestCase
+{
+    public function testDelegatesAndReturnsResultWithoutLoggingOnFastSuccess(): void
+    {
+        $stored = new StoredObject('a/b.txt', 5);
+
+        $inner = $this->createMock(ObjectStorageInterface::class);
+        $inner->expects(self::once())->method('write')->with('a/b.txt', 'hello')->willReturn($stored);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::never())->method('error');
+        $logger->expects(self::never())->method('warning');
+
+        $result = (new LoggingObjectStorage($inner, $logger, 1000))->write('a/b.txt', 'hello');
+
+        self::assertSame($stored, $result);
+    }
+
+    public function testFailureLogsErrorWithContextAndRethrows(): void
+    {
+        $inner = $this->createMock(ObjectStorageInterface::class);
+        $inner->method('read')->willThrowException(new ObjectStorageException('boom'));
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('error')
+            ->with('Object storage operation failed', self::callback(
+                static fn (array $context): bool => 'read' === $context['operation']
+                    && 'x/y.txt' === $context['path']
+                    && $context['exception'] instanceof ObjectStorageException
+                    && array_key_exists('duration_ms', $context),
+            ));
+
+        $this->expectException(ObjectStorageException::class);
+
+        (new LoggingObjectStorage($inner, $logger, 1000))->read('x/y.txt');
+    }
+
+    public function testSlowOperationLogsWarning(): void
+    {
+        $inner = $this->createMock(ObjectStorageInterface::class);
+        $inner->method('exists')->willReturn(true);
+
+        $logger = $this->createMock(LoggerInterface::class);
+        $logger->expects(self::once())
+            ->method('warning')
+            ->with('Object storage operation slow', self::callback(
+                static fn (array $context): bool => 'exists' === $context['operation'] && 'k' === $context['path'],
+            ));
+
+        // slowMs=0 → любая операция считается «медленной» (duration_ms >= 0), детерминированно.
+        $result = (new LoggingObjectStorage($inner, $logger, 0))->exists('k');
+
+        self::assertTrue($result);
+    }
+}


### PR DESCRIPTION
Наблюдаемость объектного хранилища. Принцип **liveness ≠ readiness**: сбой S3 не должен валить container `/health` php-fpm (traefik выкинул бы ноду), поэтому мониторинг — отдельно.

## #1 — Синтетический health-check
`app:storage:healthcheck` (`src/Shared/Command/`): `write → read → verify → delete` probe-объекта, замер латентности. Крон `*/5 * * * *` (`docker/cron/app.cron`).
- Сбой → `logger->error` → **GlitchTip** + exit 1. Успех → `OK (N ms)` в docker logs (heartbeat).
- Ловит недоступность S3 / протухшие ключи / рост латентности до пользователя.

## #2 — Инструментирующий декоратор
`LoggingObjectStorage` декорирует `ObjectStorageInterface` через DI (`decorates:`) — прозрачно для всего кода.
- `warning` на медленных (`> app.object_storage_slow_ms`, дефолт 1000 мс), `error` на сбоях со структурным контекстом (operation/path/duration_ms) → GlitchTip, реросит.
- Латентность + error-rate на **реальных** боевых путях.

## Проверки
- `lint:container` OK; `app:storage:healthcheck` (local) → `OK (4 ms)`.
- Новые тесты 6/6 (декоратор: passthrough / error-logs+rethrows / slow-warns; команда: healthy / failure / read-back-mismatch).
- Регрессия потребителей storage (cash worker, product import, ozon parser, download) — прозрачно ✅. CS чисто.

## Уровни логов (по правилам проекта)
`error` — сбой хранилища = инцидент (SDK уже ретраит → не transient) → GlitchTip. `warning` — медленно, само обрабатывается, в GlitchTip не идёт.

## Осознанно НЕ делали
S3 в container `/health` (amplification); circuit breaker/retry (SDK ретраит); INFO на каждую операцию (шум). Follow-ups (readiness-эндпоинт, lifecycle на `_healthcheck/`) — в `docs/tasks/s3-migration/monitoring.md`.

Пороги дефолтные (крон 5 мин, slow 1000 мс) — легко поменять.

🤖 Generated with [Claude Code](https://claude.com/claude-code)