### PR TITLE
fix(storage): harden S3 client — timeouts + retries (anti-hang / 502)

### DIFF
--- a/site/src/Shared/Service/Storage/FlysystemS3ObjectStorage.php
+++ b/site/src/Shared/Service/Storage/FlysystemS3ObjectStorage.php
@@ -28,11 +28,21 @@ final class FlysystemS3ObjectStorage implements ObjectStorageInterface
         $clientConfig = [
             'version' => 'latest',
             'region' => $region,
-            // Не декодировать Content-Encoding на стороне HTTP-клиента: мы храним уже
-            // сжатые байты (напр. .ndjson.gz) как opaque-payload и разжимаем сами.
-            // Иначе Guzzle/curl пытается авто-декодировать ответ GetObject и падает с
-            // cURL error 61 "Unrecognized content encoding type".
-            'http' => ['decode_content' => false],
+            'http' => [
+                // Не декодировать Content-Encoding: храним уже сжатые байты (.ndjson.gz)
+                // как opaque-payload и разжимаем сами. Иначе curl падает с error 61.
+                'decode_content' => false,
+                // Таймауты — чтобы блип/зависание timeweb не вешало синхронную команду
+                // (и не съедало ресурсы контейнера). Fail-fast вместо бесконечного ожидания.
+                'connect_timeout' => 5,
+                'timeout' => 30,
+            ],
+            // Авто-ретрай транзиентных сбоев (500/502/503/504 + таймауты/сеть),
+            // иначе одиночный блип timeweb = ошибка команды.
+            'retries' => [
+                'mode' => 'standard',
+                'max_attempts' => 5,
+            ],
         ];
 
         if ('' !== $endpoint) {


### PR DESCRIPTION
После флипа на S3 синхронные accrual-команды, читающие много `.gz` из S3, **зависали без таймаута** и ловили транзиентные **502** (legacy-режим SDK 502 не ретраит). Зависшее чтение внутри контейнера может его исчерпать (сегодня привело к недоступности UI при ручном прогоне reconcile в php-fpm).

## Фикс (`FlysystemS3ObjectStorage`, S3-клиент)
- `http.connect_timeout=5`, `http.timeout=30` — **fail-fast** вместо бесконечного зависания на застрявшем/медленном запросе timeweb.
- `retries: standard, max_attempts=5` — авто-ретрай транзиентных **500/502/503/504**, таймаутов и сетевых ошибок → одиночный блип timeweb не роняет команду.
- `http.decode_content=false` сохранён (gzip opaque, из #2095).

## Эффект
- Синхронные команды (reconcile/verify) и **ежедневные краны** перестают виснуть и переживают блипы timeweb → покрытие 15.06–02.07 дотянется само на следующем цикле.
- Устраняет класс «S3 моргнул → команда зависла → ресурсы контейнера исчерпаны».

## Проверка
`php -l` OK, construction-тест (клиент принимает конфиг) OK, CS чисто. Реальная валидация — на проде.

## Операционная заметка (важно)
Тяжёлые one-off команды НЕ запускать через `docker exec site-php-fpm` (живой web-контейнер) — только в отдельном/эфемерном контейнере (`site-php-cli`). Сегодняшний UI-даунтайм — от прогона reconcile в php-fpm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)